### PR TITLE
Make a workaround for the languages component in Chrome 86

### DIFF
--- a/src/sources/languages.ts
+++ b/src/sources/languages.ts
@@ -12,8 +12,8 @@ export default function getLanguages(): string[][] {
 
   if (Array.isArray(n.languages)) {
     // Starting from Chromium 86, there is only a single value in `navigator.language` in Incognito mode:
-    // the value of `navigator.language`. Wherefore the value is ignored in this browser.
-    if (!isChromium() || !isChromium86OrNewer()) {
+    // the value of `navigator.language`. Therefore the value is ignored in this browser.
+    if (!(isChromium() && isChromium86OrNewer())) {
       result.push(n.languages)
     }
   } else if (typeof n.languages === 'string') {

--- a/src/sources/languages.ts
+++ b/src/sources/languages.ts
@@ -1,3 +1,5 @@
+import { isChromium, isChromium86OrNewer } from '../utils/browser'
+
 const n = navigator
 
 export default function getLanguages(): string[][] {
@@ -9,7 +11,11 @@ export default function getLanguages(): string[][] {
   }
 
   if (Array.isArray(n.languages)) {
-    result.push(n.languages)
+    // Starting from Chromium 86, there is only a single value in `navigator.language` in Incognito mode:
+    // the value of `navigator.language`. Wherefore the value is ignored in this browser.
+    if (!isChromium() || !isChromium86OrNewer()) {
+      result.push(n.languages)
+    }
   } else if (typeof n.languages === 'string') {
     const languages = n.languages as string
     if (languages) {

--- a/src/utils/browser.ts
+++ b/src/utils/browser.ts
@@ -88,7 +88,7 @@ export function isGecko(): boolean {
 
 /**
  * Checks whether the browser is based on Chromium version ≥86 without using user-agent.
- * Doesn't checks that the browser is based on Chromium, there is a separate function for this.
+ * It doesn't check that the browser is based on Chromium, there is a separate function for this.
  */
 export function isChromium86OrNewer(): boolean {
   // Checked in Chrome 85 vs Chrome 86 both on desktop and Android

--- a/src/utils/browser.ts
+++ b/src/utils/browser.ts
@@ -85,3 +85,17 @@ export function isGecko(): boolean {
     'CanvasCaptureMediaStream' in w,
   ]) >= 4
 }
+
+/**
+ * Checks whether the browser is based on Chromium version ≥86 without using user-agent.
+ * Doesn't checks that the browser is based on Chromium, there is a separate function for this.
+ */
+export function isChromium86OrNewer(): boolean {
+  // Checked in Chrome 85 vs Chrome 86 both on desktop and Android
+  return countTruthy([
+    !('MediaSettingsRange' in w),
+    !('PhotoCapabilities' in w),
+    'RTCEncodedAudioFrame' in w,
+    ('' + w.Intl) === '[object Intl]',
+  ]) >= 2
+}


### PR DESCRIPTION
Chrome 86 was released and it gives different identifiers in normal vs incognito in certain situations. The difference is in languages array (in normal mode languages from previously used  translations are used, whereas in private mode they are not). This is different from Chrome 85 and earlier, when private mode languages also contained previous translation languages.There is the same difference in other Chromium browsers.