### PR TITLE
Fix an incorrect code snippet in the migration document

### DIFF
--- a/migrating-v2-v3.md
+++ b/migrating-v2-v3.md
@@ -44,7 +44,7 @@ The agent has a `get` method that you will use instead of calling `Fingerprint2.
 - requestIdleCallback(() => {
 + FingerprintJS.load().then(fp => {
 -   Fingerprint2.get().then(result => {
-+   fp.get(result => {
++   fp.get().then(result => {
       // Handle the result
     })
   })


### PR DESCRIPTION
Hellooo! ✨

While following the migration guide from v2 to v3, I believe I have spotted a small mistake which this pull-request would fix.

As far as I can tell, the `.get()` method from the OpenAgent does not accept a callback but returns a promise. I browsed around the code and the following snippets seem to confirm my guess:

https://github.com/fingerprintjs/fingerprintjs/blob/1254814d742fbd8a74ce1da8d105fee6d37e3fa8/src/agent.ts#L118

https://github.com/fingerprintjs/fingerprintjs/blob/1254814d742fbd8a74ce1da8d105fee6d37e3fa8/src/agent.test.ts#L7

The README also seems to imply this.

Cheers. 😊