### PR TITLE
Increase the audio component stability

### DIFF
--- a/src/sources/audio.test.ts
+++ b/src/sources/audio.test.ts
@@ -1,0 +1,20 @@
+import { getBrowserMajorVersion, isMobile, isSafari, isTrident } from '../../tests/utils'
+import getAudioFingerprint from './audio'
+
+describe('Sources', () => {
+  describe('audio', () => {
+    it('returns expected value type depending on the browser', async () => {
+      const result = await getAudioFingerprint()
+
+      if (isTrident()) {
+        expect(result).toBe(-2)
+      } else if (isSafari() && isMobile() && (getBrowserMajorVersion() ?? 0) < 12) {
+        // WebKit has stopped telling its real version in the user-agent string since version 605.1.15,
+        // therefore the browser version has to be checked instead of the engine version.
+        expect(result).toBe(-1)
+      } else {
+        expect(result).toBeGreaterThanOrEqual(0)
+      }
+    })
+  })
+})

--- a/src/sources/audio.ts
+++ b/src/sources/audio.ts
@@ -58,11 +58,13 @@ async function tryGetAudioFingerprint(AudioContext: typeof OfflineAudioContext) 
   oscillator.start(0)
 
   try {
-    const audioBuffer = await renderAudio(context)
-    return audioBuffer
-      .getChannelData(0)
-      .slice(4500, 5000)
-      .reduce((acc, val) => acc + Math.abs(val), 0)
+    const buffer = await renderAudio(context)
+    const signal = buffer.getChannelData(0)
+    let fingerprint = 0
+    for (let i = 4500; i < 5000; ++i) {
+      fingerprint += Math.abs(signal[i])
+    }
+    return fingerprint
   } catch (error) {
     return error.name === timeoutErrorName ? -3 : -4
   } finally {

--- a/src/sources/audio.ts
+++ b/src/sources/audio.ts
@@ -9,16 +9,15 @@ const enum InnerErrorName {
 
 // Inspired by and based on https://github.com/cozylife/audio-fingerprint
 export default async function getAudioFingerprint(): Promise<number> {
-  // On iOS 11, audio context can only be used in response to user interaction.
-  // We require users to explicitly enable audio fingerprinting on iOS 11.
-  // See https://stackoverflow.com/questions/46363048/onaudioprocess-not-called-on-ios11#46534088
+  // In some browsers, audio context always stays suspended unless the context is started in response to a user action
+  // (e.g. a click or a tap). It prevents audio fingerprint from being taken at an arbitrary moment of time.
+  // Such browsers are old and unpopular, so the audio fingerprinting is just skipped in them.
+  // See a similar case explanation at https://stackoverflow.com/questions/46363048/onaudioprocess-not-called-on-ios11#46534088
   if (doesCurrentBrowserSuspendAudioContext()) {
-    // See comment for excludeUserAgent and https://stackoverflow.com/questions/46363048/onaudioprocess-not-called-on-ios11#46534088
     return -1
   }
 
   const AudioContext = w.OfflineAudioContext || w.webkitOfflineAudioContext
-
   if (!AudioContext) {
     return -2
   }
@@ -27,22 +26,15 @@ export default async function getAudioFingerprint(): Promise<number> {
 
   const oscillator = context.createOscillator()
   oscillator.type = 'triangle'
-  oscillator.frequency.setValueAtTime(10000, context.currentTime)
+  setAudioParam(context, oscillator.frequency, 10000)
 
   const compressor = context.createDynamicsCompressor()
-  for (const [name, value] of [
-    ['threshold', -50],
-    ['knee', 40],
-    ['ratio', 12],
-    ['reduction', -20],
-    ['attack', 0],
-    ['release', 0.25],
-  ] as const) {
-    const param = compressor[name]
-    if (isAudioParam(param)) {
-      param.setValueAtTime(value, context.currentTime)
-    }
-  }
+  setAudioParam(context, compressor.threshold, -50)
+  setAudioParam(context, compressor.knee, 40)
+  setAudioParam(context, compressor.ratio, 12)
+  setAudioParam(context, compressor.reduction, -20)
+  setAudioParam(context, compressor.attack, 0)
+  setAudioParam(context, compressor.release, 0.25)
 
   oscillator.connect(compressor)
   compressor.connect(context.destination)
@@ -73,8 +65,13 @@ function doesCurrentBrowserSuspendAudioContext() {
   return !!matches && matches[1] === matches[2] && parseInt(matches[1]) < 12
 }
 
-function isAudioParam(value: unknown): value is AudioParam {
-  return value && typeof (value as AudioParam).setValueAtTime === 'function'
+function setAudioParam(context: BaseAudioContext, param: unknown, value: number) {
+  const isAudioParam = (value: unknown): value is AudioParam =>
+    value && typeof (value as AudioParam).setValueAtTime === 'function'
+
+  if (isAudioParam(param)) {
+    param.setValueAtTime(value, context.currentTime)
+  }
 }
 
 function renderAudio(context: OfflineAudioContext) {
@@ -94,7 +91,15 @@ function renderAudio(context: OfflineAudioContext) {
         case 'running':
           setTimeout(() => reject(makeInnerError(InnerErrorName.Timeout)), runningTimeout)
           break
+
+        // Sometimes the audio context doesn't start after calling `startRendering` (in addition to the cases where
+        // audio context doesn't start at all). A known case is starting an audio context when the browser tab is in
+        // background on iPhone. Retries usually help in this case.
         case 'suspended':
+          // The audio context can reject starting until the tab is in foreground. Long fingerprint duration
+          // in background isn't a problem, therefore the retry attempts don't count in background. It can lead to
+          // a situation when a fingerprint takes very long time to take and finishes successfully. FYI, the audio
+          // context can be suspended when `document.visibilityState === 'visible'` and start running after a retry.
           if (d.visibilityState !== 'hidden') {
             resumeTriesLeft--
           }

--- a/src/sources/audio.ts
+++ b/src/sources/audio.ts
@@ -1,4 +1,5 @@
-const n = navigator
+import { isDesktopSafari, isWebKit, isWebKit606OrNewer } from '../utils/browser'
+
 const w = window
 const d = document
 
@@ -60,9 +61,7 @@ export default async function getAudioFingerprint(): Promise<number> {
  * Checks if the current browser is known to always suspend audio context
  */
 function doesCurrentBrowserSuspendAudioContext() {
-  // todo: Find a way to detect iOS Safari 12+ without using user-agent
-  const matches = n.userAgent.match(/OS (\d+).+Version\/(\d+).+Safari/)
-  return !!matches && matches[1] === matches[2] && parseInt(matches[1]) < 12
+  return isWebKit() && !isDesktopSafari() && !isWebKit606OrNewer()
 }
 
 function setAudioParam(context: BaseAudioContext, param: unknown, value: number) {
@@ -99,8 +98,8 @@ function renderAudio(context: OfflineAudioContext) {
           // The audio context can reject starting until the tab is in foreground. Long fingerprint duration
           // in background isn't a problem, therefore the retry attempts don't count in background. It can lead to
           // a situation when a fingerprint takes very long time to take and finishes successfully. FYI, the audio
-          // context can be suspended when `document.visibilityState === 'visible'` and start running after a retry.
-          if (d.visibilityState !== 'hidden') {
+          // context can be suspended when `document.hidden === false` and start running after a retry.
+          if (!d.hidden) {
             resumeTriesLeft--
           }
           if (resumeTriesLeft > 0) {

--- a/src/sources/audio.ts
+++ b/src/sources/audio.ts
@@ -57,20 +57,25 @@ async function tryGetAudioFingerprint(AudioContext: typeof OfflineAudioContext) 
   compressor.connect(context.destination)
   oscillator.start(0)
 
+  let buffer: AudioBuffer
   try {
-    const buffer = await renderAudio(context)
-    const signal = buffer.getChannelData(0)
-    let fingerprint = 0
-    for (let i = 4500; i < 5000; ++i) {
-      fingerprint += Math.abs(signal[i])
-    }
-    return fingerprint
+    buffer = await renderAudio(context)
   } catch (error) {
-    return error.name === timeoutErrorName ? -3 : -4
+    if (error.name === timeoutErrorName) {
+      return -3
+    }
+    throw error
   } finally {
     oscillator.disconnect()
     compressor.disconnect()
   }
+
+  const signal = buffer.getChannelData(0)
+  let fingerprint = 0
+  for (let i = 4500; i < 5000; ++i) {
+    fingerprint += Math.abs(signal[i])
+  }
+  return fingerprint
 }
 
 function isAudioParam(value: unknown): value is AudioParam {

--- a/src/sources/audio.ts
+++ b/src/sources/audio.ts
@@ -97,8 +97,8 @@ function renderAudio(context: OfflineAudioContext) {
         case 'suspended':
           // The audio context can reject starting until the tab is in foreground. Long fingerprint duration
           // in background isn't a problem, therefore the retry attempts don't count in background. It can lead to
-          // a situation when a fingerprint takes very long time to take and finishes successfully. FYI, the audio
-          // context can be suspended when `document.hidden === false` and start running after a retry.
+          // a situation when a fingerprint takes very long time and finishes successfully. FYI, the audio context
+          // can be suspended when `document.hidden === false` and start running after a retry.
           if (!d.hidden) {
             resumeTriesLeft--
           }

--- a/src/sources/index.ts
+++ b/src/sources/index.ts
@@ -35,7 +35,7 @@ import areCookiesEnabled from './cookies_enabled'
  * this package.
  */
 export const sources = {
-  // Expected errors and default values must be handled inside the functions
+  // Expected errors and default values must be handled inside the functions. Unexpected errors must be thrown.
   osCpu: getOsCpu,
   languages: getLanguages,
   colorDepth: getColorDepth,

--- a/src/sources/indexed_db.test.ts
+++ b/src/sources/indexed_db.test.ts
@@ -3,18 +3,8 @@ import getIndexedDB from './indexed_db'
 
 describe('Sources', () => {
   describe('indexedDB', () => {
-    it('returns boolean everywhere except IE and Edge', () => {
-      if (isTrident() || isEdgeHTML()) {
-        pending("The case isn't for IE and Edge")
-      }
-      expect(typeof getIndexedDB()).toBe('boolean')
-    })
-
-    it('returns undefined in IE and Edge', () => {
-      if (!isTrident() && !isEdgeHTML()) {
-        pending('The case is for IE and Edge only')
-      }
-      expect(getIndexedDB()).toBeUndefined()
+    it('returns boolean or undefined depending on the browser', () => {
+      expect(typeof getIndexedDB()).toBe(isTrident() || isEdgeHTML() ? 'undefined' : 'boolean')
     })
   })
 })

--- a/src/utils/browser.test.ts
+++ b/src/utils/browser.test.ts
@@ -27,10 +27,6 @@ describe('Browser utilities', () => {
       if (!utils.isWebKit()) {
         pending('The case is for WebKit only')
       }
-      if (!utils.isMobile()) {
-        pending("Desktop Safari on BrowserStack Automate doesn't have `window.safari` for some reason")
-        // We've tested manually that desktop Safaris 9–14 do have `window.safari`
-      }
       expect(browser.isDesktopSafari()).toBe(!utils.isMobile())
     })
 
@@ -41,7 +37,7 @@ describe('Browser utilities', () => {
       expect(browser.isChromium86OrNewer()).toBe((utils.getBrowserEngineMajorVersion() ?? 0) >= 86)
     })
 
-    // WebKit has stopped telling it's real version in the user-agent string since version 605.1.15,
+    // WebKit has stopped telling its real version in the user-agent string since version 605.1.15,
     // therefore the browser version has to be checked instead of the engine version.
     it('detects Safari 12+', () => {
       if (!utils.isSafari()) {

--- a/src/utils/browser.test.ts
+++ b/src/utils/browser.test.ts
@@ -40,5 +40,14 @@ describe('Browser utilities', () => {
       }
       expect(browser.isChromium86OrNewer()).toBe((utils.getBrowserEngineMajorVersion() ?? 0) >= 86)
     })
+
+    // WebKit has stopped telling it's real version in the user-agent string since version 605.1.15,
+    // therefore the browser version has to be checked instead of the engine version.
+    it('detects Safari 12+', () => {
+      if (!utils.isSafari()) {
+        pending('The case is for Safari only')
+      }
+      expect(browser.isWebKit606OrNewer()).toBe((utils.getBrowserMajorVersion() ?? 0) >= 606)
+    })
   })
 })

--- a/src/utils/browser.test.ts
+++ b/src/utils/browser.test.ts
@@ -47,7 +47,7 @@ describe('Browser utilities', () => {
       if (!utils.isSafari()) {
         pending('The case is for Safari only')
       }
-      expect(browser.isWebKit606OrNewer()).toBe((utils.getBrowserMajorVersion() ?? 0) >= 606)
+      expect(browser.isWebKit606OrNewer()).toBe((utils.getBrowserMajorVersion() ?? 0) >= 12)
     })
   })
 })

--- a/src/utils/browser.ts
+++ b/src/utils/browser.ts
@@ -90,7 +90,14 @@ export function isWebKit(): boolean {
  * This function is out of Semantic Versioning, i.e. can change unexpectedly. Usage is at your own risk.
  */
 export function isDesktopSafari(): boolean {
-  return 'safari' in w
+  return (
+    countTruthy([
+      'safari' in w, // Always false in BrowserStack Automate
+      !('DeviceMotionEvent' in w),
+      !('ongestureend' in w),
+      !('standalone' in n),
+    ]) >= 3
+  )
 }
 
 /**

--- a/src/utils/browser.ts
+++ b/src/utils/browser.ts
@@ -128,3 +128,21 @@ export function isChromium86OrNewer(): boolean {
     ]) >= 3
   )
 }
+
+/**
+ * Checks whether the browser is based on WebKit version ≥606 (Safari ≥12) without using user-agent.
+ * It doesn't check that the browser is based on WebKit, there is a separate function for this.
+ *
+ * @link https://en.wikipedia.org/wiki/Safari_version_history#Release_history Safari-WebKit versions map
+ */
+export function isWebKit606OrNewer(): boolean {
+  // Checked in Safari 9–14
+  return (
+    countTruthy([
+      'DOMRectList' in w,
+      'RTCPeerConnectionIceEvent' in w,
+      'SVGGeometryElement' in w,
+      'ontransitioncancel' in w,
+    ]) >= 3
+  )
+}

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -39,7 +39,8 @@ export function isMobile(): boolean {
  * Probably you should use `isWebKit` instead
  */
 export function isSafari(): boolean {
-  return new UAParser().getBrowser().name === 'Safari'
+  const browserName = new UAParser().getBrowser().name
+  return browserName === 'Safari' || browserName === 'Mobile Safari'
 }
 
 /**

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -35,6 +35,24 @@ export function isMobile(): boolean {
   return new UAParser().getDevice().type === 'mobile'
 }
 
+/**
+ * Probably you should use `isWebKit` instead
+ */
+export function isSafari(): boolean {
+  return new UAParser().getBrowser().name === 'Safari'
+}
+
+/**
+ * Probably you should use `getBrowserEngineMajorVersion` instead
+ */
+export function getBrowserMajorVersion(): number | undefined {
+  const version = new UAParser().getBrowser().version
+  if (version === undefined) {
+    return undefined
+  }
+  return parseInt(version.split('.')[0])
+}
+
 export function getBrowserEngineMajorVersion(): number | undefined {
   const version = new UAParser().getEngine().version
   if (version === undefined) {


### PR DESCRIPTION
The audio component can return `-3` on iPhone when the browser tab is hidden (in background or the device is locked). This PR makes the library retry getting the audio fingerprint while the page is hidden. It helps to get stable audio fingerprint in all the cases that I've succeeded to reproduce.

Also I've made iOS 9–10 always return `-2` because the audio component doesn't run on these versions, no matter what I try.