### PR TITLE
Fix cookie 'SameSite' attribute warning in Firefox (#599)

### DIFF
--- a/src/sources/cookies_enabled.ts
+++ b/src/sources/cookies_enabled.ts
@@ -18,10 +18,10 @@ export default function areCookiesEnabled(): boolean {
   // or in sandboxed iframes (depending on flags/context)
   try {
     // Create cookie
-    d.cookie = 'cookietest=1'
+    d.cookie = 'cookietest=1; SameSite=Strict; Secure;'
     const result = d.cookie.indexOf('cookietest=') !== -1
     // Delete cookie
-    d.cookie = 'cookietest=1; expires=Thu, 01-Jan-1970 00:00:01 GMT'
+    d.cookie = 'cookietest=1; SameSite=Strict; Secure; expires=Thu, 01-Jan-1970 00:00:01 GMT'
     return result
   } catch (e) {
     return false

--- a/src/sources/cookies_enabled.ts
+++ b/src/sources/cookies_enabled.ts
@@ -18,10 +18,10 @@ export default function areCookiesEnabled(): boolean {
   // or in sandboxed iframes (depending on flags/context)
   try {
     // Create cookie
-    d.cookie = 'cookietest=1; SameSite=Strict; Secure;'
+    d.cookie = 'cookietest=1; SameSite=Strict;'
     const result = d.cookie.indexOf('cookietest=') !== -1
     // Delete cookie
-    d.cookie = 'cookietest=1; SameSite=Strict; Secure; expires=Thu, 01-Jan-1970 00:00:01 GMT'
+    d.cookie = 'cookietest=1; SameSite=Strict; expires=Thu, 01-Jan-1970 00:00:01 GMT'
     return result
   } catch (e) {
     return false


### PR DESCRIPTION
This fix adds the SameSource Attribute and the Secure Attribute to the cookie test.
SameSource is set to 'Strict' so that only the website that the cookie will have access to it, making it a first-party cookie according to [Mozilla](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite).
