### PR TITLE
Fix migration documentation custom components example

### DIFF
--- a/docs/migrating_v2_v3.md
+++ b/docs/migrating_v2_v3.md
@@ -101,7 +101,7 @@ Use the provided hash function to achieve this:
 const result = await fp.get()
 
 // Exclude a couple components
-const { languages, audio, ...components } = result
+const { languages, audio, ...components } = result.components
 
 // Add a few custom components
 const extendedComponents = {


### PR DESCRIPTION
Components cannot be destructured from the `result` resolved by `fp.get()`. It should instead be destructured from the `.components` key 😄 

First PR here, apologies if anything is off (couldn't see much in the contributing guidelines for docs)