### PR TITLE
Fix the platform detection on iOS

### DIFF
--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -38,5 +38,5 @@ interface Screen {
 }
 
 interface Element {
-  webkitRequestFullscreen?: Element['requestFullscreen']
+  webkitRequestFullscreen?: typeof Element.prototype.requestFullscreen
 }

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -36,3 +36,7 @@ interface Screen {
   availLeft?: number
   availTop?: number
 }
+
+interface Element {
+  webkitRequestFullscreen?: Element['requestFullscreen']
+}

--- a/src/sources/platform.ts
+++ b/src/sources/platform.ts
@@ -1,7 +1,18 @@
-/**
- * It should be improved to handle mock value on iOS:
- * https://github.com/fingerprintjs/fingerprintjs/issues/514#issuecomment-727782842
- */
+import { isDesktopSafari, isIPad, isWebKit } from '../utils/browser'
+
 export default function getPlatform(): string {
-  return navigator.platform
+  // Android Chrome 86 and 87 and Android Firefox 80 and 84 don't mock the platform value when desktop mode is requested
+  const { platform } = navigator
+
+  // iOS mocks the platform value when desktop version is requested: https://github.com/fingerprintjs/fingerprintjs/issues/514
+  // iPad uses desktop mode by default since iOS 13
+  // The value is 'MacIntel' on M1 Macs
+  // The value is 'iPhone' on iPod Touch
+  if (platform === 'MacIntel') {
+    if (isWebKit() && !isDesktopSafari()) {
+      return isIPad() ? 'iPad' : 'iPhone'
+    }
+  }
+
+  return platform
 }

--- a/src/utils/browser.test.ts
+++ b/src/utils/browser.test.ts
@@ -27,7 +27,7 @@ describe('Browser utilities', () => {
       if (!utils.isWebKit()) {
         pending('The case is for WebKit only')
       }
-      expect(browser.isDesktopSafari()).toBe(!utils.isMobile())
+      expect(browser.isDesktopSafari()).toBe(!utils.isMobile() && !utils.isTablet())
     })
 
     it('detects Chromium 86+', () => {
@@ -44,6 +44,14 @@ describe('Browser utilities', () => {
         pending('The case is for Safari only')
       }
       expect(browser.isWebKit606OrNewer()).toBe((utils.getBrowserMajorVersion() ?? 0) >= 12)
+    })
+
+    it('detects iPad', () => {
+      // Unfortunately, UA-parser can't detect an iPad that pretends to be a Mac
+      if (!utils.isWebKit() || !(utils.isMobile() || utils.isTablet())) {
+        pending('The case is for mobile WebKit only')
+      }
+      expect(browser.isIPad()).toBe(utils.isTablet())
     })
   })
 })

--- a/src/utils/browser.ts
+++ b/src/utils/browser.ts
@@ -155,6 +155,29 @@ export function isWebKit606OrNewer(): boolean {
 }
 
 /**
+ * Checks whether the device is an iPad.
+ * It doesn't check that the engine is WebKit and that the WebKit isn't desktop.
+ */
+export function isIPad(): boolean {
+  // todo: Check in other iOS browsers
+  // Before iOS 13
+  if (n.platform === 'iPad') {
+    return true
+  }
+
+  const s = screen
+  const screenRatio = s.width / s.height
+
+  return (
+    countTruthy([
+      'MediaSource' in w, // Since iOS 13
+      !!Element.prototype.webkitRequestFullscreen, // Since iOS 12
+      screenRatio > 2 / 3 && screenRatio < 3 / 2,
+    ]) >= 2
+  )
+}
+
+/**
  * Warning for package users:
  * This function is out of Semantic Versioning, i.e. can change unexpectedly. Usage is at your own risk.
  */

--- a/src/utils/browser.ts
+++ b/src/utils/browser.ts
@@ -159,8 +159,13 @@ export function isWebKit606OrNewer(): boolean {
  * It doesn't check that the engine is WebKit and that the WebKit isn't desktop.
  */
 export function isIPad(): boolean {
-  // todo: Check in other iOS browsers
-  // Before iOS 13
+  // Checked on:
+  // Safari on iPadOS (both mobile and desktop modes): 8, 11, 12, 13, 14
+  // Chrome on iPadOS (both mobile and desktop modes): 11, 12, 13, 14
+  // Safari on iOS (both mobile and desktop modes): 9, 10, 11, 12, 13, 14
+  // Chrome on iOS (both mobile and desktop modes): 9, 10, 11, 12, 13, 14
+
+  // Before iOS 13. Safari tampers the value in "request desktop site" mode since iOS 13.
   if (n.platform === 'iPad') {
     return true
   }

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -35,6 +35,10 @@ export function isMobile(): boolean {
   return new UAParser().getDevice().type === 'mobile'
 }
 
+export function isTablet(): boolean {
+  return new UAParser().getDevice().type === 'tablet'
+}
+
 /**
  * Probably you should use `isWebKit` instead
  */


### PR DESCRIPTION
Resolves #514

The changes go to `next-sources` because they change the fingerprint of almost all iPad users.