### PR TITLE
Make FingerprintJS work in SSR environment

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,9 @@ jobs:
         run: yarn build
       - name: Check the distributive TypeScript declarations
         run: yarn test:dts
+        # Helps to prevent https://github.com/fingerprintjs/fingerprintjs/issues/602
+      - name: Check the ability to work with server side rendering
+        run: yarn test:ssr
       - name: Test on BrowserStack
         env:
           BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "lint:fix": "yarn lint --fix",
     "test:local": "karma start tests/karma.local.config.js --single-run",
     "test:browserstack": "karma start tests/karma.browserstack.config.js --single-run",
-    "test:dts": "tsc --noEmit dist/fp.d.ts"
+    "test:dts": "tsc --noEmit dist/fp.d.ts",
+    "test:ssr": "node --require './dist/fp.cjs.js' --eval '' || (echo \"The distributive files can't be used with server side rendering. Make sure the code doesn't use browser API until an exported function is called.\" && exit 1)"
   },
   "dependencies": {
     "tslib": "^2.0.1"

--- a/src/sources/adblock.ts
+++ b/src/sources/adblock.ts
@@ -1,6 +1,6 @@
-const d = document
-
 export default function isAdblockUsed(): boolean {
+  const d = document
+
   if (!d.body?.appendChild) {
     return false
   }

--- a/src/sources/audio.ts
+++ b/src/sources/audio.ts
@@ -1,8 +1,5 @@
 import { isDesktopSafari, isWebKit, isWebKit606OrNewer } from '../utils/browser'
 
-const w = window
-const d = document
-
 const enum SpecialFingerprint {
   /** Making a fingerprint is skipped because the browser is known to always suspend audio context */
   KnownToSuspend = -1,
@@ -19,6 +16,7 @@ const enum InnerErrorName {
 
 // Inspired by and based on https://github.com/cozylife/audio-fingerprint
 export default async function getAudioFingerprint(): Promise<number> {
+  const w = window
   const AudioContext = w.OfflineAudioContext || w.webkitOfflineAudioContext
   if (!AudioContext) {
     return SpecialFingerprint.NotSupported
@@ -108,7 +106,7 @@ function renderAudio(context: OfflineAudioContext) {
           // in background isn't a problem, therefore the retry attempts don't count in background. It can lead to
           // a situation when a fingerprint takes very long time and finishes successfully. FYI, the audio context
           // can be suspended when `document.hidden === false` and start running after a retry.
-          if (!d.hidden) {
+          if (!document.hidden) {
             resumeTriesLeft--
           }
           if (resumeTriesLeft > 0) {

--- a/src/sources/available_screen_resolution.ts
+++ b/src/sources/available_screen_resolution.ts
@@ -1,14 +1,15 @@
 import { toInt } from '../utils/data'
 
-const w = window
-
 export default function getAvailableScreenResolution(): [number, number] | undefined {
-  if (w.screen.availWidth && w.screen.availHeight) {
+  const s = screen
+
+  if (s.availWidth && s.availHeight) {
     // Some browsers return screen resolution as strings, e.g. "1200", instead of a number, e.g. 1200.
     // I suspect it's done by certain plugins that randomize browser properties to prevent fingerprinting.
-    const dimensions = [toInt(w.screen.availWidth), toInt(w.screen.availHeight)] as [number, number]
+    const dimensions = [toInt(s.availWidth), toInt(s.availHeight)] as [number, number]
     dimensions.sort().reverse()
     return dimensions
   }
+
   return undefined
 }

--- a/src/sources/cookies_enabled.ts
+++ b/src/sources/cookies_enabled.ts
@@ -1,5 +1,3 @@
-const d = document
-
 /**
  * navigator.cookieEnabled cannot detect custom or nuanced cookie blocking configurations. For example, when blocking
  * cookies via the Advanced Privacy Settings in IE9, it always returns true. And there have been issues in the past with
@@ -8,6 +6,8 @@ const d = document
  * @see https://github.com/Modernizr/Modernizr/blob/master/feature-detects/cookies.js Taken from here
  */
 export default function areCookiesEnabled(): boolean {
+  const d = document
+
   // Taken from here: https://github.com/Modernizr/Modernizr/blob/master/feature-detects/cookies.js
   // navigator.cookieEnabled cannot detect custom or nuanced cookie blocking configurations. For example, when blocking
   // cookies via the Advanced Privacy Settings in IE9, it always returns true. And there have been issues in the past

--- a/src/sources/fonts.ts
+++ b/src/sources/fonts.ts
@@ -1,5 +1,3 @@
-const d = document
-
 // We use m or w because these two characters take up the maximum width.
 // And we use a LLi so that the same matching fonts can get separated.
 const testString = 'mmMwWLliI0O&1'
@@ -91,7 +89,8 @@ const fontSpanStyle = {
 
 // kudos to http://www.lalit.org/lab/javascript-css-font-detect/
 export default function getFonts(): string[] {
-  const h = d.body
+  const d = document
+  const holder = d.body
 
   // div to load spans for the base fonts
   const baseFontsDiv = d.createElement('div')
@@ -160,7 +159,7 @@ export default function getFonts(): string[] {
   const baseFontsSpans = initializeBaseFontsSpans()
 
   // add the spans to the DOM
-  h.appendChild(baseFontsDiv)
+  holder.appendChild(baseFontsDiv)
 
   // get the default width for the three base fonts
   for (let index = 0, length = baseFonts.length; index < length; index++) {
@@ -172,7 +171,7 @@ export default function getFonts(): string[] {
   const fontsSpans = initializeFontsSpans()
 
   // add all the spans to the DOM
-  h.appendChild(fontsDiv)
+  holder.appendChild(fontsDiv)
 
   // check available fonts
   const available: string[] = []
@@ -183,7 +182,7 @@ export default function getFonts(): string[] {
   }
 
   // remove spans from DOM
-  h.removeChild(fontsDiv)
-  h.removeChild(baseFontsDiv)
+  holder.removeChild(fontsDiv)
+  holder.removeChild(baseFontsDiv)
   return available
 }

--- a/src/sources/languages.ts
+++ b/src/sources/languages.ts
@@ -1,8 +1,7 @@
 import { isChromium, isChromium86OrNewer } from '../utils/browser'
 
-const n = navigator
-
 export default function getLanguages(): string[][] {
+  const n = navigator
   const result: string[][] = []
 
   const language = n.language || n.userLanguage || n.browserLanguage || n.systemLanguage

--- a/src/sources/screen_resolution.ts
+++ b/src/sources/screen_resolution.ts
@@ -1,11 +1,11 @@
 import { toInt } from '../utils/data'
 
-const w = window
-
 export default function getScreenResolution(): [number, number] {
+  const s = screen
+
   // Some browsers return screen resolution as strings, e.g. "1200", instead of a number, e.g. 1200.
   // I suspect it's done by certain plugins that randomize browser properties to prevent fingerprinting.
-  const dimensions = [toInt(w.screen.width), toInt(w.screen.height)] as [number, number]
+  const dimensions = [toInt(s.width), toInt(s.height)] as [number, number]
   dimensions.sort().reverse()
   return dimensions
 }

--- a/src/sources/timezone.ts
+++ b/src/sources/timezone.ts
@@ -1,8 +1,7 @@
-const w = window
-
 export default function getTimezone(): string | undefined {
-  if (w.Intl?.DateTimeFormat) {
-    return new w.Intl.DateTimeFormat().resolvedOptions().timeZone
+  const DateTimeFormat = window.Intl?.DateTimeFormat
+  if (DateTimeFormat) {
+    return new DateTimeFormat().resolvedOptions().timeZone
   }
   return undefined
 }

--- a/src/sources/touch_support.ts
+++ b/src/sources/touch_support.ts
@@ -1,8 +1,5 @@
 import { toInt } from '../utils/data'
 
-const n = navigator
-const w = window
-
 export interface TouchSupport {
   maxTouchPoints: number
   /** The success or failure of creating a TouchEvent */
@@ -19,6 +16,8 @@ export interface TouchSupport {
  * @see https://github.com/Modernizr/Modernizr/issues/548
  */
 export default function getTouchSupport(): TouchSupport {
+  const n = navigator
+
   let maxTouchPoints = 0
   let touchEvent: boolean
   if (n.maxTouchPoints !== undefined) {
@@ -32,7 +31,7 @@ export default function getTouchSupport(): TouchSupport {
   } catch (_) {
     touchEvent = false
   }
-  const touchStart = 'ontouchstart' in w
+  const touchStart = 'ontouchstart' in window
   return {
     maxTouchPoints,
     touchEvent,

--- a/src/utils/async.ts
+++ b/src/utils/async.ts
@@ -1,9 +1,8 @@
-const w = window
-
 export function requestIdleCallbackIfAvailable(fallbackTimeout: number, deadlineTimeout = Infinity): Promise<void> {
   return new Promise((resolve) => {
-    if (w.requestIdleCallback) {
-      w.requestIdleCallback(() => resolve(), { timeout: deadlineTimeout })
+    const { requestIdleCallback } = window
+    if (requestIdleCallback) {
+      requestIdleCallback(() => resolve(), { timeout: deadlineTimeout })
     } else {
       setTimeout(resolve, Math.min(fallbackTimeout, deadlineTimeout))
     }

--- a/src/utils/browser.ts
+++ b/src/utils/browser.ts
@@ -4,10 +4,6 @@ import { countTruthy } from './data'
  * Functions to help with features that vary through browsers
  */
 
-const w = window
-const n = navigator
-const d = document
-
 /**
  * Checks whether the browser is based on Trident (the Internet Explorer engine) without using user-agent.
  *
@@ -15,6 +11,9 @@ const d = document
  * This function is out of Semantic Versioning, i.e. can change unexpectedly. Usage is at your own risk.
  */
 export function isTrident(): boolean {
+  const w = window
+  const n = navigator
+
   // The properties are checked to be in IE 10, IE 11 and not to be in other browsers in October 2020
   return (
     countTruthy([
@@ -35,6 +34,9 @@ export function isTrident(): boolean {
  */
 export function isEdgeHTML(): boolean {
   // Based on research in October 2020
+  const w = window
+  const n = navigator
+
   return (
     countTruthy(['msWriteProfilerMark' in w, 'MSStream' in w, 'msLaunchUri' in n, 'msSaveBlob' in n]) >= 3 &&
     !isTrident()
@@ -49,6 +51,9 @@ export function isEdgeHTML(): boolean {
  */
 export function isChromium(): boolean {
   // Based on research in October 2020. Tested to detect Chromium 42-86.
+  const w = window
+  const n = navigator
+
   return (
     countTruthy([
       'webkitPersistentStorage' in n,
@@ -71,6 +76,9 @@ export function isChromium(): boolean {
  */
 export function isWebKit(): boolean {
   // Based on research in September 2020
+  const w = window
+  const n = navigator
+
   return (
     countTruthy([
       'ApplePayError' in w,
@@ -90,12 +98,14 @@ export function isWebKit(): boolean {
  * This function is out of Semantic Versioning, i.e. can change unexpectedly. Usage is at your own risk.
  */
 export function isDesktopSafari(): boolean {
+  const w = window
+
   return (
     countTruthy([
       'safari' in w, // Always false in Karma and BrowserStack Automate
       !('DeviceMotionEvent' in w),
       !('ongestureend' in w),
-      !('standalone' in n),
+      !('standalone' in navigator),
     ]) >= 3
   )
 }
@@ -107,11 +117,13 @@ export function isDesktopSafari(): boolean {
  * This function is out of Semantic Versioning, i.e. can change unexpectedly. Usage is at your own risk.
  */
 export function isGecko(): boolean {
+  const w = window
+
   // Based on research in September 2020
   return (
     countTruthy([
-      'buildID' in n,
-      d.documentElement?.style && 'MozAppearance' in d.documentElement.style,
+      'buildID' in navigator,
+      'MozAppearance' in (document.documentElement?.style ?? {}),
       'MediaRecorderErrorEvent' in w,
       'mozInnerScreenX' in w,
       'CSSMozDocumentRule' in w,
@@ -126,6 +138,8 @@ export function isGecko(): boolean {
  */
 export function isChromium86OrNewer(): boolean {
   // Checked in Chrome 85 vs Chrome 86 both on desktop and Android
+  const w = window
+
   return (
     countTruthy([
       !('MediaSettingsRange' in w),
@@ -144,6 +158,8 @@ export function isChromium86OrNewer(): boolean {
  */
 export function isWebKit606OrNewer(): boolean {
   // Checked in Safari 9–14
+  const w = window
+
   return (
     countTruthy([
       'DOMRectList' in w,


### PR DESCRIPTION
Closes #602

Makes it easier to run FingerprintJS with Node.js server side rendering tools like [ReactDOMServer](https://reactjs.org/docs/react-dom-server.html), [Next.js](https://nextjs.org), [Nuxt.js](https://nuxtjs.org) and [Gatsby](http://gatsbyjs.com). Keep in mind that `FingerprintJS.load()` isn't designed to run on server, so you should call in on client side only. If you use React, you can implement it with [useEffect](https://reactjs.org/docs/hooks-reference.html#useeffect).

```jsx
// This line would throw an error if you run this code on server side before this PR.
// Now it works fine.
import * as FingerpirntJS from '@fingerprintjs/fignerprintjs';

import React, { useEffect } from 'react';

export default function SSRComponent() {
  useEffect(() => {
    // The code inside this function runs only on client side, so it's ok to call FingerprintJS.load() here
    FingerprintJS.load()
      .then(fp => fp.get())
      .then(result => console.log('Visitor ID:', result.visitorId));
  }, []);

  return <div>Hello</div>;
}
```

PoC: [nextjs-test.zip](https://github.com/fingerprintjs/fingerprintjs/files/5949103/nextjs-test.zip)
