### PR TITLE
Fix: use iframe.contentDocument instead

### DIFF
--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -47,6 +47,7 @@ export async function withIframe<T>(
       // See https://github.com/fingerprintjs/fingerprintjs/issues/645
       const checkReadyState = () => {
         // Make sure iframe.contentWindow and iframe.contentWindow.document are both loaded
+        // The contentWindow.document can miss in JSDOM (https://github.com/jsdom/jsdom).
         if (iframe.contentWindow?.document?.readyState === 'complete') {
           resolve()
         } else {

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -46,6 +46,7 @@ export async function withIframe<T>(
       // This code checks for the loading state manually.
       // See https://github.com/fingerprintjs/fingerprintjs/issues/645
       const checkReadyState = () => {
+        // Make sure iframe.contentWindow and iframe.contentWindow.document are both loaded
         if (iframe.contentWindow?.document?.readyState === 'complete') {
           resolve()
         } else {

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -46,7 +46,7 @@ export async function withIframe<T>(
       // This code checks for the loading state manually.
       // See https://github.com/fingerprintjs/fingerprintjs/issues/645
       const checkReadyState = () => {
-        if (iframe.contentWindow?.document.readyState === 'complete') {
+        if (iframe.contentWindow?.document?.readyState === 'complete') {
           resolve()
         } else {
           setTimeout(checkReadyState, 10)
@@ -55,7 +55,7 @@ export async function withIframe<T>(
       checkReadyState()
     })
 
-    while (!iframe.contentDocument?.body) {
+    while (!iframe.contentWindow?.document?.body) {
       await wait(domPollInterval)
     }
 

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -55,7 +55,7 @@ export async function withIframe<T>(
       checkReadyState()
     })
 
-    while (!iframe.contentWindow?.document.body) {
+    while (!iframe.contentDocument?.body) {
       await wait(domPollInterval)
     }
 


### PR DESCRIPTION
Sometimes iframe.contentWindow is loaded while iframe.contentWindow.document is still null, and cause an exception