### PR TITLE
Use more reliable CDN snippets that work in GTM

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -8,24 +8,38 @@ The library is shipped in various formats:
 
 ```html
 <script>
-  function initFingerprintJS() {
-    // Start loading FingerprintJS here
-  }
+  // Initialize the agent at application startup.
+  const fpPromise = new Promise((resolve, reject) => {
+    const script = document.createElement('script')
+    script.onload = resolve
+    script.onerror = reject
+    script.async = true
+    script.src = 'https://cdn.jsdelivr.net/npm/'
+      + '@fingerprintjs/fingerprintjs@3/dist/fp.min.js'
+    document.head.appendChild(script)
+  })
+    .then(() => FingerprintJS.load())
+
+  // Get the visitor identifier when you need it.
+  fpPromise
+    .then(fp => fp.get())
+    .then(result => console.log(result.visitorId))
 </script>
-<script
-  async
-  src="//cdn.jsdelivr.net/npm/@fingerprintjs/fingerprintjs@3/dist/fp.min.js"
-  onload="initFingerprintJS()"
-></script>
 ```
 
 ### UMD
 
 ```js
 require(
-  ['//cdn.jsdelivr.net/npm/@fingerprintjs/fingerprintjs@3/dist/fp.umd.min.js'],
+  ['https://cdn.jsdelivr.net/npm/@fingerprintjs/fingerprintjs@3/dist/fp.umd.min.js'],
   (FingerprintJS) => {
-    // Start loading FingerprintJS here
+    // Initialize the agent at application startup.
+    const fpPromise = FingerprintJS.load()
+
+    // Get the visitor identifier when you need it.
+    fpPromise
+      .then(fp => fp.get())
+      .then(result => console.log(result.visitorId))
   }
 )
 ```
@@ -42,7 +56,15 @@ yarn add @fingerprintjs/fingerprintjs
 ```js
 import FingerprintJS from '@fingerprintjs/fingerprintjs'
 
-// Start loading FingerprintJS here
+// Initialize an agent at application startup.
+const fpPromise = FingerprintJS.load()
+
+;(async () => {
+  // Get the visitor identifier when you need it.
+  const fp = await fpPromise
+  const result = await fp.get()
+  console.log(result.visitorId)
+})()
 ```
 
 If you face a TypeScript error that occurs in a FingerprintJS file,
@@ -60,7 +82,13 @@ yarn add @fingerprintjs/fingerprintjs
 ```js
 const FingerprintJS = require('@fingerprintjs/fingerprintjs')
 
-// Start loading FingerprintJS here
+// Initialize the agent at application startup.
+const fpPromise = FingerprintJS.load()
+
+// Get the visitor identifier when you need it.
+fpPromise
+  .then(fp => fp.get())
+  .then(result => console.log(result.visitorId))
 ```
 
 ## API

--- a/docs/api.md
+++ b/docs/api.md
@@ -27,6 +27,21 @@ The library is shipped in various formats:
 </script>
 ```
 
+Or a synchronous code that blocks the page during loading and therefore isn't recommended:
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/@fingerprintjs/fingerprintjs@3/dist/fp.min.js"></script>
+<script>
+  // Initialize the agent at application startup.
+  const fpPromise = FingerprintJS.load()
+
+  // Get the visitor identifier when you need it.
+  fpPromise
+    .then(fp => fp.get())
+    .then(result => console.log(result.visitorId))
+</script>
+```
+
 ### UMD
 
 ```js

--- a/docs/browser_support.md
+++ b/docs/browser_support.md
@@ -47,6 +47,14 @@ Examples for various installation methods:
           })
       </script>
     ```
+    If you use a synchronous loading:
+    ```diff
+    + <script src="https://cdn.jsdelivr.net/npm/promise-polyfill@8/dist/polyfill.min.js"></script>
+      <script src="https://cdn.jsdelivr.net/npm/@fingerprintjs/fingerprintjs@3/dist/fp.min.js"></script>
+      <script>
+        // ...
+      </script>
+    ```
 - UMD
     ```diff
       require(

--- a/docs/browser_support.md
+++ b/docs/browser_support.md
@@ -31,27 +31,31 @@ Examples for various installation methods:
 
 - Global variable
     ```diff
+    + <script src="https://cdn.jsdelivr.net/npm/promise-polyfill@8/dist/polyfill.min.js"></script>
       <script>
-        function initFingerprintJS() {
-          // Start loading FingerprintJS here
-        }
+        const fpPromise = new Promise((resolve, reject) => {
+          const script = document.createElement('script')
+          script.onload = resolve
+          script.onerror = reject
+          script.async = true
+          script.src = 'https://cdn.jsdelivr.net/npm/'
+            + '@fingerprintjs/fingerprintjs@3/dist/fp.min.js'
+          document.head.appendChild(script)
+        })
+          .then(() => {
+            // ...
+          })
       </script>
-    + <script src="//cdn.jsdelivr.net/npm/promise-polyfill@8/dist/polyfill.min.js"></script>
-      <script
-        async
-        src="//cdn.jsdelivr.net/npm/@fingerprintjs/fingerprintjs@3/dist/fp.min.js"
-        onload="initFingerprintJS()"
-      ></script>
     ```
 - UMD
     ```diff
       require(
         [
-          '//cdn.jsdelivr.net/npm/@fingerprintjs/fingerprintjs@3/dist/fp.umd.min.js',
-    +     '//cdn.jsdelivr.net/npm/promise-polyfill@8/dist/polyfill.min.js',
+          'https://cdn.jsdelivr.net/npm/@fingerprintjs/fingerprintjs@3/dist/fp.umd.min.js',
+    +     'https://cdn.jsdelivr.net/npm/promise-polyfill@8/dist/polyfill.min.js',
         ],
         (FingerprintJS) => {
-          // Start loading FingerprintJS here
+          // ...
         }
       )
     ```
@@ -67,7 +71,7 @@ Examples for various installation methods:
     + import 'promise-polyfill/src/polyfill'
       import FingerprintJS from '@fingerprintjs/fingerprintjs'
 
-      // Start loading FingerprintJS here
+      // ...
     ```
 - CommonJS
     ```bash
@@ -81,7 +85,7 @@ Examples for various installation methods:
     + require('promise-polyfill/src/polyfill')
       const FingerprintJS = require('@fingerprintjs/fingerprintjs')
 
-      // Start loading FingerprintJS here
+      // ...
     ```
 
 ### Code syntax

--- a/readme.md
+++ b/readme.md
@@ -33,25 +33,27 @@ FingerprintJS is a browser fingerprinting library that queries browser attribute
 
 ```html
 <script>
-  function initFingerprintJS() {
-    // Initialize an agent at application startup.
-    const fpPromise = FingerprintJS.load()
+  // Initialize the agent at application startup.
+  const fpPromise = new Promise((resolve, reject) => {
+    const script = document.createElement('script')
+    script.onload = resolve
+    script.onerror = reject
+    script.async = true
+    script.src = 'https://cdn.jsdelivr.net/npm/'
+      + '@fingerprintjs/fingerprintjs@3/dist/fp.min.js'
+    document.head.appendChild(script)
+  })
+    .then(() => FingerprintJS.load())
 
-    // Get the visitor identifier when you need it.
-    fpPromise
-      .then(fp => fp.get())
-      .then(result => {
-        // This is the visitor identifier:
-        const visitorId = result.visitorId
-        console.log(visitorId)
-      })
-  }
+  // Get the visitor identifier when you need it.
+  fpPromise
+    .then(fp => fp.get())
+    .then(result => {
+      // This is the visitor identifier:
+      const visitorId = result.visitorId
+      console.log(visitorId)
+    })
 </script>
-<script
-  async
-  src="//cdn.jsdelivr.net/npm/@fingerprintjs/fingerprintjs@3/dist/fp.min.js"
-  onload="initFingerprintJS()"
-></script>
 ```
 
 [Run this code](https://stackblitz.com/edit/fpjs-3-cdn?file=index.html&devtoolsheight=100)
@@ -110,7 +112,7 @@ Full product comparison:
   </thead>
   <tbody>
     <tr><td colspan="3"><h4>Core Features</h4></td></tr>
-      <tr><td>100% Open-source</td><td align="center">yes</td><td align="center">no<sup>1</sup></td></tr>
+    <tr><td>100% Open-source</td><td align="center">yes</td><td align="center">no<sup>1</sup></td></tr>
     <tr><td><b>Standard fingerprint signals</b><br/><i>screen, os, device name</i></td><td align="center">✓</td><td align="center">✓</td></tr>
     <tr><td><b>Advanced fingerprint signals</b><br/><i>canvas, audio, fonts</i></td><td align="center">✓</td><td align="center">✓</td></tr>
     <tr><td><b>ID type</b></td><td align="center">fingerprint</td><td align="center">visitorID<sup>2</sup></td></tr>
@@ -147,9 +149,10 @@ Pro result example:
   "requestId": "HFMlljrzKEiZmhUNDx7Z",
   "visitorId": "kHqPGWS1Mj18sZFsP8Wl",
   "visitorFound": true,
+  "confidence": { "score": 0.995 },
   "incognito": false,
   "browserName": "Chrome",
-  "browserVersion": "85.0.4183",
+  "browserVersion": "92.0.4515.107",
   "os": "Mac OS X",
   "osVersion": "10.15.6",
   "device": "Other",


### PR DESCRIPTION
Our current snippets (with asynchronous `<script>`s with `onload` attributes) don't work in environments that don't respect `onload` attribute during running HTML snippets (e.g. Google Tag Manager and StackBlitz).