### PR TITLE
Replace obsolete link with a working one

### DIFF
--- a/src/sources/canvas.ts
+++ b/src/sources/canvas.ts
@@ -95,7 +95,7 @@ function makeGeometryImage(canvas: HTMLCanvasElement, context: CanvasRenderingCo
   }
 
   // Canvas winding
-  // http://blogs.adobe.com/webplatform/2013/01/30/winding-rules-in-canvas/
+  // https://web.archive.org/web/20130913061632/http://blogs.adobe.com/webplatform/2013/01/30/winding-rules-in-canvas/
   // http://jsfiddle.net/NDYV8/19/
   context.fillStyle = '#f9c'
   context.arc(60, 60, 60, 0, Math.PI * 2, true)


### PR DESCRIPTION
The old link gives 404: https://blog.adobe.com/webplatform/2013/01/30/winding-rules-in-canvas/

I've tried to find the article in Adobe blog using their search but found nothing: https://helpx.adobe.com/globalsearch.html?q=winding+rules&start_index=0&country=TR&activeScopes=%5B%22adobe_com%3Ablog%22%5D&scopeConfigs=%5B%7B%22value%22%3A%22adobe_com%3Ablog%22%2C%22renderStyle%22%3A%22vert%22%2C%22seeMoreLink%22%3Anull%2C%22isSelectable%22%3Atrue%7D%5D&filters=%7B%22products%22%3A%5B%5D%7D&banners=%7B%22aboveResults%22%3A%7B%22count%22%3A3%2C%22ids%22%3A%5B%22auto%22%5D%7D%2C%22sidebar%22%3A%7B%22count%22%3A0%2C%22ids%22%3A%5B%5D%7D%7D&ctrls=%7B%22prodFilts%22%3Afalse%7D&gnavExp=blogs%2Fblog-gnav

The article still can be found in web archive