### PR TITLE
Use setInterval instead of recursively calling setTimeout

### DIFF
--- a/src/sources/dom_blockers.ts
+++ b/src/sources/dom_blockers.ts
@@ -1,7 +1,7 @@
 import { isAndroid, isWebKit } from '../utils/browser'
 import { selectorToElement } from '../utils/dom'
 import { countTruthy } from '../utils/data'
-import { wait } from '../utils/async'
+import { waitUntil } from '../utils/async'
 
 /**
  * Only single element selector are supported (no operators like space, +, >, etc).
@@ -326,10 +326,8 @@ export async function getBlockedSelectors<T extends string>(selectors: readonly 
   }
 
   // document.body can be null while the page is loading
-  while (!d.body) {
-    await wait(50)
-  }
-  d.body.appendChild(root)
+  const body = d.body || (await waitUntil(() => d.body, 50))
+  body.appendChild(root)
 
   try {
     // Then check which of the elements are blocked

--- a/src/utils/async.ts
+++ b/src/utils/async.ts
@@ -4,6 +4,24 @@ export function wait<T = void>(durationMs: number, resolveWith?: T): Promise<T> 
   return new Promise((resolve) => setTimeout(resolve, durationMs, resolveWith))
 }
 
+export function waitUntil<T>(condition: () => T, intervalMs: number): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const checkCondition = () => {
+      try {
+        const v = condition()
+        if (v) {
+          resolve(v)
+          clearInterval(timerId)
+        }
+      } catch (e) {
+        reject(e)
+        clearInterval(timerId)
+      }
+    }
+    const timerId = setInterval(checkCondition, intervalMs)
+  })
+}
+
 export function requestIdleCallbackIfAvailable(fallbackTimeout: number, deadlineTimeout = Infinity): Promise<void> {
   const { requestIdleCallback } = window
   if (requestIdleCallback) {

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -1,4 +1,4 @@
-import { wait } from './async'
+import { waitUntil } from './async'
 import { parseSimpleCssSelector } from './data'
 
 /**
@@ -19,8 +19,8 @@ export async function withIframe<T>(
   const d = document
 
   // document.body can be null while the page is loading
-  while (!d.body) {
-    await wait(domPollInterval)
+  if (!d.body) {
+    await waitUntil(() => d.body, domPollInterval)
   }
 
   const iframe = d.createElement('iframe')
@@ -56,11 +56,12 @@ export async function withIframe<T>(
       const timerId = setInterval(checkReadyState, 10)
     })
 
-    while (!iframe.contentWindow?.document?.body) {
-      await wait(domPollInterval)
+    const haveContentBody = () => !!iframe.contentWindow?.document?.body
+    if (!haveContentBody()) {
+      await waitUntil(haveContentBody, domPollInterval)
     }
 
-    return await action(iframe, iframe.contentWindow)
+    return await action(iframe, iframe.contentWindow as Window)
   } finally {
     iframe.parentNode?.removeChild(iframe)
   }

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -50,11 +50,10 @@ export async function withIframe<T>(
         // The contentWindow.document can miss in JSDOM (https://github.com/jsdom/jsdom).
         if (iframe.contentWindow?.document?.readyState === 'complete') {
           resolve()
-        } else {
-          setTimeout(checkReadyState, 10)
+          clearInterval(timerId)
         }
       }
-      checkReadyState()
+      const timerId = setInterval(checkReadyState, 10)
     })
 
     while (!iframe.contentWindow?.document?.body) {


### PR DESCRIPTION
Today I noticed Slack.com constantly hogging cpu (in Firefox 94). After some digging in profiler and through obfuscated/minified js, I landed on this function:
https://github.com/fingerprintjs/fingerprintjs/blob/e0f1771bd8e87535e99bb632b6315c55fd8dd202/src/utils/dom.ts#L48-L56
which spends ~20ms per second in `setTimeout`. Should be using `setInterval` instead.

Then looking through the surrounding code I saw more loops repeatedly calling `setTimeout` while waiting for a condition. So I replaced those with `setInterval` as well.
