### PR TITLE
Reduce the number of NPM monitoring requests

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -67,8 +67,9 @@ const fpPromise = FingerprintJS.load()
 
 [Run this code](https://stackblitz.com/edit/fpjs-3-npm?file=index.js&devtoolsheight=100)
 
-When you run FingerprintJS installed with NPM or Yarn, the library will periodically send AJAX requests to FingerprintJS servers to collect usage statistics.
-The requests are sent once a week from one browser instance (unless the browser cache was cleared).
+When you run FingerprintJS installed with NPM or Yarn, the library will send AJAX requests to FingerprintJS servers to collect usage statistics.
+When the `load` function runs, there is a 1% chance of sending a request.
+The requests are sent at most once a week from one browser instance (unless the browser cache was cleared).
 A request includes the following information:
 
 - The library version

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -183,7 +183,7 @@ components: ${componentsToDebugString(components)}
  */
 function monitor() {
   // The FingerprintJS CDN (https://github.com/fingerprintjs/cdn) replaces `window.__fpjs_d_m` with `true`
-  if (window.__fpjs_d_m) {
+  if (window.__fpjs_d_m || Math.random() >= 0.01) {
     return
   }
   try {


### PR DESCRIPTION
Send the requests on every 100 runs instead of every run