### PR TITLE
Added video card entropy source

### DIFF
--- a/src/sources/index.ts
+++ b/src/sources/index.ts
@@ -31,6 +31,7 @@ import isMotionReduced from './reduced_motion'
 import isHDR from './hdr'
 import getMathFingerprint from './math'
 import getFontPreferences from './font_preferences'
+import getVideoCard from './video_card'
 
 /**
  * The list of entropy sources used to make visitor identifiers.
@@ -78,6 +79,7 @@ export const sources = {
   reducedMotion: isMotionReduced,
   hdr: isHDR,
   math: getMathFingerprint,
+  videoCard: getVideoCard,
 }
 
 /**

--- a/src/sources/video_card.test.ts
+++ b/src/sources/video_card.test.ts
@@ -2,35 +2,15 @@ import getVideoCard from './video_card'
 
 describe('Sources', () => {
   describe('videoCard', () => {
-    const videoCard = getVideoCard()
-    it('to be defined', () => {
-      expect(videoCard).toBeDefined()
+    it('to be correctly typed if defined', () => {
+      const videoCard = getVideoCard()
+
+      if (videoCard) {
+        expect(videoCard).toEqual({
+          vendor: jasmine.any(String),
+          renderer: jasmine.any(String),
+        })
+      }
     })
-
-    // Doesn't work
-    // it needs the object to be exactly like what I provided and I only need the keys
-    // it('has vendor and renderer', () => {
-    //   expect(videoCard).toEqual(
-    //     jasmine.objectContaining({
-    //       vendor: 'Graphics card vendor',
-    //       renderer: 'Graphics card renderer',
-    //     }),
-    //   )
-    // })
-
-    // Throws Error
-    // it('has vendor and renderer', () => {
-    //   expect(Object.keys(videoCard)).toEqual(['vendor', 'renderer'])
-    // })
-
-    // Didn't work
-    // it('contain vendor', () => {
-    //   expect(videoCard).toContain('vendor')
-    // })
-    // it('contain renderer', () => {
-    //   expect(videoCard).toContain('renderer')
-    // })
-
-    // I give up
   })
 })

--- a/src/sources/video_card.test.ts
+++ b/src/sources/video_card.test.ts
@@ -1,10 +1,18 @@
 import getVideoCard from './video_card'
+import { isGecko } from '../utils/browser'
+import { getBrowserMajorVersion } from '../../tests/utils'
 
 describe('Sources', () => {
   describe('videoCard', () => {
-    it('to be correctly typed if defined', () => {
-      const videoCard = getVideoCard()
+    const videoCard = getVideoCard()
 
+    it('to be defined', () => {
+      if (!isGecko() || (getBrowserMajorVersion() ?? Infinity) >= 53) {
+        expect(videoCard).toBeTruthy()
+      }
+    })
+
+    it('to be correctly typed if defined', () => {
       if (videoCard) {
         expect(videoCard).toEqual({
           vendor: jasmine.any(String),

--- a/src/sources/video_card.test.ts
+++ b/src/sources/video_card.test.ts
@@ -1,0 +1,36 @@
+import getVideoCard from './video_card'
+
+describe('Sources', () => {
+  describe('videoCard', () => {
+    const videoCard = getVideoCard()
+    it('to be defined', () => {
+      expect(videoCard).toBeDefined()
+    })
+
+    // Doesn't work
+    // it needs the object to be exactly like what I provided and I only need the keys
+    // it('has vendor and renderer', () => {
+    //   expect(videoCard).toEqual(
+    //     jasmine.objectContaining({
+    //       vendor: 'Graphics card vendor',
+    //       renderer: 'Graphics card renderer',
+    //     }),
+    //   )
+    // })
+
+    // Throws Error
+    // it('has vendor and renderer', () => {
+    //   expect(Object.keys(videoCard)).toEqual(['vendor', 'renderer'])
+    // })
+
+    // Didn't work
+    // it('contain vendor', () => {
+    //   expect(videoCard).toContain('vendor')
+    // })
+    // it('contain renderer', () => {
+    //   expect(videoCard).toContain('renderer')
+    // })
+
+    // I give up
+  })
+})

--- a/src/sources/video_card.test.ts
+++ b/src/sources/video_card.test.ts
@@ -1,18 +1,15 @@
 import getVideoCard from './video_card'
-import { isGecko } from '../utils/browser'
-import { getBrowserMajorVersion } from '../../tests/utils'
+import { isGecko, getBrowserMajorVersion } from '../../tests/utils'
 
 describe('Sources', () => {
   describe('videoCard', () => {
-    const videoCard = getVideoCard()
+    it('to be correctly typed if defined', () => {
+      const videoCard = getVideoCard()
 
-    it('to be defined', () => {
       if (!isGecko() || (getBrowserMajorVersion() ?? Infinity) >= 53) {
         expect(videoCard).toBeTruthy()
       }
-    })
 
-    it('to be correctly typed if defined', () => {
       if (videoCard) {
         expect(videoCard).toEqual({
           vendor: jasmine.any(String),

--- a/src/sources/video_card.ts
+++ b/src/sources/video_card.ts
@@ -1,20 +1,20 @@
-/*
- * Credits: https://stackoverflow.com/a/49267844
- */
-
 export interface VideoCard {
   vendor: string
   renderer: string
 }
 
+/**
+ * @see Credits: https://stackoverflow.com/a/49267844
+ */
 export default function getVideoCard(): VideoCard | undefined {
-  const gl = document.createElement('canvas').getContext('webgl')
-  if (gl) {
+  const canvas = document.createElement('canvas')
+  const gl = canvas.getContext('webgl') ?? canvas.getContext('experimental-webgl')
+  if (gl && 'getExtension' in gl) {
     const debugInfo = gl.getExtension('WEBGL_debug_renderer_info')
     if (debugInfo) {
       return {
-        vendor: gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL),
-        renderer: gl.getParameter(debugInfo.UNMASKED_RENDERER_WEBGL),
+        vendor: gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL).toString(),
+        renderer: gl.getParameter(debugInfo.UNMASKED_RENDERER_WEBGL).toString(),
       }
     }
   }

--- a/src/sources/video_card.ts
+++ b/src/sources/video_card.ts
@@ -1,0 +1,22 @@
+/*
+ * Credits: https://stackoverflow.com/a/49267844
+ */
+
+export interface VideoCard {
+  vendor: string
+  renderer: string
+}
+
+export default function getVideoCard(): VideoCard | undefined {
+  const gl = document.createElement('canvas').getContext('webgl')
+  if (gl) {
+    const debugInfo = gl.getExtension('WEBGL_debug_renderer_info')
+    if (debugInfo) {
+      return {
+        vendor: gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL),
+        renderer: gl.getParameter(debugInfo.UNMASKED_RENDERER_WEBGL),
+      }
+    }
+  }
+  return undefined
+}

--- a/src/sources/video_card.ts
+++ b/src/sources/video_card.ts
@@ -13,8 +13,8 @@ export default function getVideoCard(): VideoCard | undefined {
     const debugInfo = gl.getExtension('WEBGL_debug_renderer_info')
     if (debugInfo) {
       return {
-        vendor: gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL).toString(),
-        renderer: gl.getParameter(debugInfo.UNMASKED_RENDERER_WEBGL).toString(),
+        vendor: (gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL) || '').toString(),
+        renderer: (gl.getParameter(debugInfo.UNMASKED_RENDERER_WEBGL) || '').toString(),
       }
     }
   }


### PR DESCRIPTION
Hello again !

I tried to make a unit test for the entropy source but failed miserably. Jasmin has very bad docs and I couldn't really know how to do just one simple thing.

However here is my tests for the entropy source for one laptop one very old desktop and an android phone

### Device 1 (HP Laptop)
**Relevant specs**
Integrated video card: Intel(R) HD Graphics 630
Dedicated video card: NVIDIA GeForce GTX 1050

**Chrome v97.0.4692.71**
> "videoCard": {
    "value": {
      "vendor": "Google Inc. (Intel)",
      "renderer": "ANGLE (Intel, Intel(R) HD Graphics 630 Direct3D11 vs_5_0 ps_5_0, D3D11-27.20.100.8681)"
    },
    "duration": 12
  }

**Chrome v97.0.4692.71 with WebGL Fingerprint Defender v0.1.5**

> "videoCard": {
    "value": {
      "vendor": "Google Inc.",
      "renderer": "Graphics"
    },
    "duration": 9
  }

**Chrome v97.0.4692.71 with Fingerprint Spoofing v1.3.2**

> "videoCard": {
    "value": {
      "vendor": 3672,
      "renderer": 3672
    },
    "duration": 9
  }

**Firefox v95.0.2 (64-bit)**

> "videoCard": {
    "value": {
      "vendor": "Google Inc. (Intel)",
      "renderer": "ANGLE (Intel(R) HD Graphics 400 Direct3D11 vs_5_0 ps_5_0, D3D11-27.20.100.8681)"
    },
    "duration": 21
  }

**Firefox v95.0.2 (64-bit) with Enhanced Tracking Protection on Strict mode**

> "videoCard": {
    "value": {
      "vendor": "Google Inc. (Intel)",
      "renderer": "ANGLE (Intel(R) HD Graphics 400 Direct3D11 vs_5_0 ps_5_0, D3D11-27.20.100.8681)"
    },
    "duration": 17
  }

**Firefox v95.0.2 (64-bit) with WebGL Fingerprint defender**

> "videoCard": {
    "value": {
      "vendor": "Google Inc.",
      "renderer": "HD Graphics"
    },
    "duration": 17
  }

**Brave Version 1.34.80 Chromium: 97.0.4692.71**

> "videoCard": {
    "value": {
      "vendor": "Google Inc. (NVIDIA)",
      "renderer": "ANGLE (NVIDIA, NVIDIA GeForce GTX 1050 Direct3D11 vs_5_0 ps_5_0, D3D11-30.0.14.7247)"
    },
    "duration": 14
  }

**Brave Version 1.34.80 Chromium: 97.0.4692.71  Fingerprinting blocking (Standard)**

> "videoCard": {
    "value": {
      "vendor": "Google Inc. (NVIDIA)",
      "renderer": "ANGLE (NVIDIA, NVIDIA GeForce GTX 1050 Direct3D11 vs_5_0 ps_5_0, D3D11-30.0.14.7247)"
    },
    "duration": 11
  }

**Brave Version 1.34.80 Chromium: 97.0.4692.71  Fingerprinting blocking (Strict)**

> "videoCard": {
    "value": {
      "vendor": "Xr169ePH",
      "renderer": "aNmTJECh"
    },
    "duration": 11
  }

**Opera v82.0.4227.43**
> "videoCard": {
    "value": {
      "vendor": "Google Inc. (Intel)",
      "renderer": "ANGLE (Intel, Intel(R) HD Graphics 630 Direct3D11 vs_5_0 ps_5_0, D3D11-27.20.100.8681)"
    },
    "duration": 13
  }


### Device 2 (Android Phone)

**Relevant specs**
Integrated video card: Exynos: Mali-G71 MP20 Snapdragon: Adreno 540

**Chrome 96.0.4664.104**
> "videoCard": {
    "value": {
      "vendor": "ARM",
      "renderer": "Mali-G71"
    },
    "duration": 20
  }

**Firefox 95.2.0 Strict Tracking Protection**
> "videoCard": {
    "value": {
      "vendor": "ARM",
      "renderer": "Mali-G51"
    },
    "duration": 83
  }

### Device 3 (HP Desktop)

**Relevant specs**
Integrated video card: ATI Radeon HD 4200

**Opera v82.0.4227.43**
> "videoCard": {
    "value": {
      "vendor": "Google Inc. (Google)",
      "renderer": "ANGLE (Google, Vulkan 1.2.0 (SwiftShader Device (Subzero) (0x000C0DE)), SwiftShader driver-5.0.0)"
    },
    "duration": 20
  }
