### PR TITLE
Throttle the NPM monitoring requests harder

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -68,7 +68,7 @@ const fpPromise = FingerprintJS.load()
 [Run this code](https://stackblitz.com/edit/fpjs-3-npm?file=index.js&devtoolsheight=100)
 
 **When you run FingerprintJS installed with NPM or Yarn, the library will send AJAX requests to FingerprintJS servers to collect usage statistics.**
-When the `load` function runs, there is a 1% chance of sending a request.
+When the `load` function runs, there is a 0.1% chance of sending a request.
 The requests are sent at most once a week from one browser instance (unless the browser cache was cleared).
 A request includes the following information:
 

--- a/docs/migrating_v1_v3.md
+++ b/docs/migrating_v1_v3.md
@@ -32,6 +32,9 @@ yarn remove fingerprintjs2
 yarn add @fingerprintjs/fingerprintjs
 ```
 
+The new version sends HTTP requests to collect usage statistics, they can be disabled.
+See [this page](api.md#webpackrollupnpmyarn) for more details.
+
 Remove the type declaration package.
 You don't need it because the type declaration is embedded into the main package in v3:
 

--- a/docs/migrating_v2_v3.md
+++ b/docs/migrating_v2_v3.md
@@ -30,6 +30,9 @@ npm install @fingerprintjs/fingerprintjs
 yarn add @fingerprintjs/fingerprintjs
 ```
 
+The new version sends HTTP requests to collect usage statistics, they can be disabled.
+See [this page](api.md#webpackrollupnpmyarn) for more details.
+
 Remove the type declaration package.
 You don't need it because the type declaration is embedded into the main package in v3:
 

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -183,7 +183,7 @@ components: ${componentsToDebugString(components)}
  */
 function monitor() {
   // The FingerprintJS CDN (https://github.com/fingerprintjs/cdn) replaces `window.__fpjs_d_m` with `true`
-  if (window.__fpjs_d_m || Math.random() >= 0.01) {
+  if (window.__fpjs_d_m || Math.random() >= 0.001) {
     return
   }
   try {

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -188,7 +188,7 @@ function monitor() {
   }
   try {
     const request = new XMLHttpRequest()
-    request.open('get', `https://openfpcdn.io/fingerprintjs/v${version}/npm-monitoring`, true)
+    request.open('get', `https://m1.openfpcdn.io/fingerprintjs/v${version}/npm-monitoring`, true)
     request.send()
   } catch (error) {
     // console.error is ok here because it's an unexpected error handler


### PR DESCRIPTION
- The 1% throttling was tightened to 0.1%
- Using a separate domain name: m1.openfpcdn.io