### PR TITLE
Add an entropy source based on `navigator.pdfViewerEnabled`

### DIFF
--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -20,6 +20,7 @@ interface Navigator {
   systemLanguage?: string
   deviceMemory?: number
   cpuClass?: string
+  pdfViewerEnabled?: boolean
 }
 
 interface Document {

--- a/src/sources/index.ts
+++ b/src/sources/index.ts
@@ -32,6 +32,7 @@ import isHDR from './hdr'
 import getMathFingerprint from './math'
 import getFontPreferences from './font_preferences'
 import getVideoCard from './video_card'
+import isPdfViewerEnabled from './pdf_viewer_enabled'
 
 /**
  * The list of entropy sources used to make visitor identifiers.
@@ -83,6 +84,7 @@ export const sources = {
   hdr: isHDR,
   math: getMathFingerprint,
   videoCard: getVideoCard,
+  pdfViewerEnabled: isPdfViewerEnabled,
 }
 
 /**

--- a/src/sources/pdf_viewer_enabled.test.ts
+++ b/src/sources/pdf_viewer_enabled.test.ts
@@ -1,0 +1,9 @@
+import isPdfViewerEnabled from './pdf_viewer_enabled'
+
+describe('Sources', () => {
+  describe('pdvViewerEnabled', () => {
+    it('returns boolean or undefined', () => {
+      expect(['boolean', 'undefined']).toContain(typeof isPdfViewerEnabled())
+    })
+  })
+})

--- a/src/sources/pdf_viewer_enabled.ts
+++ b/src/sources/pdf_viewer_enabled.ts
@@ -1,0 +1,3 @@
+export default function isPdfViewerEnabled(): boolean | undefined {
+  return navigator.pdfViewerEnabled
+}


### PR DESCRIPTION
Helps mitigate #794

Merging into the `next-sources` branch which contains changes that break the fingerprint compatibility, and therefore will be merged into `master` in v3.4.0.