### PR TITLE
Enable Karma debug logging automatically in GitHub Actions retries

### DIFF
--- a/.github/workflows/check_upcoming_browser_versions.yml
+++ b/.github/workflows/check_upcoming_browser_versions.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Build
         run: yarn build
       - name: Run unit tests
-        run: yarn test:browserstack:beta
+        run: yarn test:browserstack:beta --log-level ${{ github.run_attempt == 1 && 'info' || 'debug' }}
       - name: Post to a Slack channel
         id: slack
         uses: slackapi/slack-github-action@v1.23.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,4 +41,4 @@ jobs:
         env:
           BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
           BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
-        run: yarn test:browserstack
+        run: yarn test:browserstack --log-level ${{ github.run_attempt == 1 && 'info' || 'debug' }}


### PR DESCRIPTION
It will help collecting BrowserStack debug data when a problem happens during testing in this repository.

-------------

I also considered to enable debug-level logging when the debug option checkbox is on (`--log-level ${{ runner.debug ? 'debug' : 'info' }}`).

<img width="688" alt="Screenshot 2023-04-05 at 20 57 06" src="https://user-images.githubusercontent.com/9006227/230074173-2042a06f-eb6e-4961-a4a5-eae703fd90e1.png">

But decided to turn it on for every retry because it's more reliable.