### PR TITLE
Automatically retry unit tests if they fail

### DIFF
--- a/.github/workflows/check_upcoming_browser_versions.yml
+++ b/.github/workflows/check_upcoming_browser_versions.yml
@@ -6,7 +6,9 @@
 
 name: Check upcoming browser versions
 
-on: [push, pull_request]
+on: 
+  schedule:
+    - cron: '0 17 ? * MON-FRI'
 env:
   BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
   BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}

--- a/.github/workflows/check_upcoming_browser_versions.yml
+++ b/.github/workflows/check_upcoming_browser_versions.yml
@@ -16,7 +16,7 @@ jobs:
   unit_tests:
     name: Run unit tests
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     concurrency: browserstack
     steps:
       - name: Checkout
@@ -34,6 +34,7 @@ jobs:
       - name: Run unit tests
         uses: nick-fields/retry@v2
         with:
+          timeout_minutes: 5
           max_attempts: 2
           retry_on: error
           command: yarn test:browserstack:beta

--- a/.github/workflows/check_upcoming_browser_versions.yml
+++ b/.github/workflows/check_upcoming_browser_versions.yml
@@ -34,7 +34,12 @@ jobs:
       - name: Build
         run: yarn build
       - name: Run unit tests
-        run: yarn test:browserstack:beta --log-level ${{ github.run_attempt == 1 && 'info' || 'debug' }}
+        uses: nick-fields/retry@v2
+        with:
+          max_attempts: 2
+          retry_on: error
+          command: yarn test:browserstack:beta
+          new_command_on_retry: yarn test:browserstack:beta --log-level debug
       - name: Post to a Slack channel
         id: slack
         uses: slackapi/slack-github-action@v1.23.0

--- a/.github/workflows/check_upcoming_browser_versions.yml
+++ b/.github/workflows/check_upcoming_browser_versions.yml
@@ -6,9 +6,7 @@
 
 name: Check upcoming browser versions
 
-on:
-  schedule:
-    - cron: '0 17 ? * MON-FRI'
+on: [push, pull_request]
 env:
   BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
   BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}


### PR DESCRIPTION
So far, the only failures we have experienced were fixed by retrying manually, so in order to reduce the reason to react to false failures, we could use a retry. 
More on this action here:
https://github.com/marketplace/actions/retry-step