### PR TITLE
feature: Add Media Recorder Source

### DIFF
--- a/src/sources/index.ts
+++ b/src/sources/index.ts
@@ -34,6 +34,7 @@ import getFontPreferences from './font_preferences'
 import getVideoCard from './video_card'
 import isPdfViewerEnabled from './pdf_viewer_enabled'
 import getArchitecture from './architecture'
+import getMediaRecorderSupportedTypes from './media_recorder'
 
 /**
  * The list of entropy sources used to make visitor identifiers.
@@ -87,6 +88,7 @@ export const sources = {
   videoCard: getVideoCard,
   pdfViewerEnabled: isPdfViewerEnabled,
   architecture: getArchitecture,
+  supportedMediaRecorderTypes: getMediaRecorderSupportedTypes,
 }
 
 /**

--- a/src/sources/media_recorder.test.ts
+++ b/src/sources/media_recorder.test.ts
@@ -1,0 +1,17 @@
+import getMediaRecorderSupportedTypes from './media_recorder'
+
+describe('getMediaRecorderSupportedTypes', () => {
+  it('returns an array of strings', () => {
+    const supportedTypes = getMediaRecorderSupportedTypes() ?? []
+    expect(Array.isArray(supportedTypes)).toBe(true)
+    supportedTypes.forEach((type) => {
+      expect(typeof type).toBe('string')
+    })
+  })
+
+  it('returns undefined if MediaRecorder.isTypeSupported is undefined', () => {
+    MediaRecorder.isTypeSupported = undefined as unknown as typeof MediaRecorder['isTypeSupported']
+    const supportedTypes = getMediaRecorderSupportedTypes()
+    expect(supportedTypes).toEqual(undefined)
+  })
+})

--- a/src/sources/media_recorder.ts
+++ b/src/sources/media_recorder.ts
@@ -1,0 +1,19 @@
+const MIME_TYPES = [
+  'video/webm',
+  'audio/webm',
+  'video/x-matroska',
+  'video/x-matroska;codecs=h264',
+  'audio/ogg',
+  'video/mp4',
+  'audio/mp4',
+]
+
+/**
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/MediaRecorder/isTypeSupported_static
+ */
+export default function getMediaRecorderSupportedTypes(): string[] | undefined {
+  if (typeof MediaRecorder?.isTypeSupported === 'undefined') {
+    return undefined
+  }
+  return MIME_TYPES.filter(MediaRecorder.isTypeSupported)
+}


### PR DESCRIPTION
The `MediaRecorder.isTypeSupported` method determines which MIME types are supported by a user's browser to be recorded to a blob.