### PR TITLE
feature: Add supported media constraints source

### DIFF
--- a/src/sources/index.ts
+++ b/src/sources/index.ts
@@ -34,6 +34,7 @@ import getFontPreferences from './font_preferences'
 import getVideoCard from './video_card'
 import isPdfViewerEnabled from './pdf_viewer_enabled'
 import getArchitecture from './architecture'
+import getSupportedMediaConstraints from './media-constraints'
 
 /**
  * The list of entropy sources used to make visitor identifiers.
@@ -87,6 +88,7 @@ export const sources = {
   videoCard: getVideoCard,
   pdfViewerEnabled: isPdfViewerEnabled,
   architecture: getArchitecture,
+  supportedMediaConstraints: getSupportedMediaConstraints,
 }
 
 /**

--- a/src/sources/media-constraints.test.ts
+++ b/src/sources/media-constraints.test.ts
@@ -1,0 +1,11 @@
+import getSupportedMediaConstraints from './media-constraints'
+
+describe('getSupportedMediaConstraints', () => {
+  it('should return undefined if navigator.mediaDevices.getSupportedConstraints is not supported', async () => {
+    Object.defineProperty(navigator, 'mediaDevices', {
+      value: {},
+    })
+    const constraints = await getSupportedMediaConstraints()
+    expect(constraints).toBeUndefined()
+  })
+})

--- a/src/sources/media-constraints.ts
+++ b/src/sources/media-constraints.ts
@@ -1,0 +1,9 @@
+/**
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getSupportedConstraints
+ */
+export default async function getSupportedMediaConstraints() {
+  if (!navigator?.mediaDevices?.getSupportedConstraints) {
+    return undefined
+  }
+  return navigator.mediaDevices.getSupportedConstraints()
+}


### PR DESCRIPTION
The getSupportedConstraints() method of the [MediaDevices](https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices) interface returns an object based on the [MediaTrackSupportedConstraints](https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackSupportedConstraints) dictionary, whose member fields each specify one of the constrainable properties the [user agent](https://developer.mozilla.org/en-US/docs/Glossary/User_agent) understands.