### PR TITLE
feat: non-ASCII support and optimization in `murmurhash3`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -48,3 +48,4 @@ export {
   UnknownSources,
 } from './utils/entropy_source'
 export { withIframe } from './utils/dom'
+export { getUTF8Bytes } from './utils/data'

--- a/src/utils/data.test.ts
+++ b/src/utils/data.test.ts
@@ -1,4 +1,4 @@
-import { areSetsEqual, maxInIterator, parseSimpleCssSelector, round, toFloat, toInt } from './data'
+import { areSetsEqual, getUTF8Bytes, maxInIterator, parseSimpleCssSelector, round, toFloat, toInt } from './data'
 
 describe('Data utilities', () => {
   it('converts to integer', () => {
@@ -99,5 +99,12 @@ describe('Data utilities', () => {
     expect(maxInIterator(generator(), (item) => -item.val)).toEqual({ val: 1 })
     expect(maxInIterator(generator(), (item) => (item.val % 2 === 0 ? item.val : item.val * 2))).toEqual({ val: 7 })
     expect(maxInIterator(emptyGenerator(), () => Math.random())).toBeUndefined()
+  })
+
+  it('converts string to UTF8 bytes', () => {
+    expect(getUTF8Bytes('Hello, world!')).toEqual(
+      new Uint8Array([72, 101, 108, 108, 111, 44, 32, 119, 111, 114, 108, 100, 33]),
+    )
+    expect(getUTF8Bytes('fё%?=🤔')).toEqual(new Uint8Array([102, 209, 145, 37, 63, 61, 240, 159, 164, 148]))
   })
 })

--- a/src/utils/data.ts
+++ b/src/utils/data.ts
@@ -149,3 +149,42 @@ export function maxInIterator<T>(iterator: Iterator<T>, getItemScore: (item: T) 
 
   return maxItem
 }
+
+function encode(text: string): Uint8Array {
+  // Benchmark: https://jsbench.me/b6klaaxgwq/1
+  // If you want to just count bytes, see solutions at https://jsbench.me/ehklab415e/1
+  if (typeof TextEncoder === 'function') {
+    return new TextEncoder().encode(text) // From https://stackoverflow.com/a/11411402/1118709
+  }
+
+  // From https://stackoverflow.com/a/18722848/1118709
+  const binaryText = unescape(encodeURI(text))
+  const bytes = new Uint8Array(binaryText.length)
+
+  for (let i = 0; i < binaryText.length; ++i) {
+    bytes[i] = binaryText.charCodeAt(i)
+  }
+
+  return bytes
+}
+
+/**
+ * Converts a string to UTF8 bytes
+ *
+ * Warning for package users:
+ * This function is out of Semantic Versioning, i.e. can change unexpectedly. Usage is at your own risk.
+ */
+export function getUTF8Bytes(input: string): Uint8Array {
+  const result = new Uint8Array(input.length)
+  for (let i = 0; i < input.length; i++) {
+    // `charCode` is faster than encoding so we prefer that when it's possible
+    const charCode = input.charCodeAt(i)
+
+    // In case of non-ASCII symbols we use proper encoding
+    if (charCode < 0 || charCode > 127) {
+      return encode(input)
+    }
+    result[i] = charCode
+  }
+  return result
+}

--- a/src/utils/hashing.test.ts
+++ b/src/utils/hashing.test.ts
@@ -26,7 +26,15 @@ const longText =
 
 describe('Murmur3', () => {
   it('makes x64 128 bit hash', () => {
-    expect(x64hash128('Hello, world')).toBe('ebd28b45027ab97477416103e3fff7b8')
+    const input = 'Hello, world, hi'
+    const nonAsciiInput = 'ňťŬŬůĬĠŷůŲŬŤĬĠŨũ' // 'Hello, world, hi' + 256 codepoints for each to make it non-ASCII
+    const shortInput = 'hello'
+
+    expect(x64hash128(input)).not.toBe(x64hash128(nonAsciiInput))
+
+    expect(x64hash128(input)).toBe('9a66b4567d520770dc8eaf9a508ecf1b')
+    expect(x64hash128(nonAsciiInput)).toBe('460892d2cab76edff07f62a97e106f6b')
+    expect(x64hash128(shortInput)).toBe('cbd8a7b341bd9b025b1e906a48ae1d19')
     expect(x64hash128(longText)).toBe('211a6f425b82e115fb52ccdc51edb290')
   })
 })

--- a/src/utils/hashing.test.ts
+++ b/src/utils/hashing.test.ts
@@ -27,6 +27,10 @@ const longText =
 describe('Murmur3', () => {
   it('makes x64 128 bit hash', () => {
     const input = 'Hello, world, hi'
+    const inputLessThanChunk = 'Hello, world, h'
+    const inputGreaterThanChunk = 'Hello, world, hi!'
+    const inputGreaterThan2Chunks = 'Hello, world, hi, Hello, world, hi'
+
     const nonAsciiInput = 'ňťŬŬůĬĠŷůŲŬŤĬĠŨũ' // 'Hello, world, hi' + 256 codepoints for each to make it non-ASCII
     const shortInput = 'hello'
 
@@ -36,5 +40,8 @@ describe('Murmur3', () => {
     expect(x64hash128(nonAsciiInput)).toBe('460892d2cab76edff07f62a97e106f6b')
     expect(x64hash128(shortInput)).toBe('cbd8a7b341bd9b025b1e906a48ae1d19')
     expect(x64hash128(longText)).toBe('211a6f425b82e115fb52ccdc51edb290')
+    expect(x64hash128(inputLessThanChunk)).toBe('4552c6409e0a7bd3b0f9eb318bb35f05')
+    expect(x64hash128(inputGreaterThanChunk)).toBe('dce3e02d43da4d2374e84e484c566492')
+    expect(x64hash128(inputGreaterThan2Chunks)).toBe('d49c261c833b671870b471c42df4dbf0')
   })
 })

--- a/src/utils/hashing.ts
+++ b/src/utils/hashing.ts
@@ -2,29 +2,40 @@
  * Taken from https://github.com/karanlyons/murmurHash3.js/blob/a33d0723127e2e5415056c455f8aed2451ace208/murmurHash3.js
  */
 
-//
-// Given two 64bit ints (as an array of two 32bit ints) returns the two
-// added together as a 64bit int (as an array of two 32bit ints).
-//
+/**
+ * Adds two 64-bit values (provided as tuples of 32-bit values)
+ * and updates (mutates) first value to write the result
+ */
 function x64Add(m: number[], n: number[]) {
-  m = [m[0] >>> 16, m[0] & 0xffff, m[1] >>> 16, m[1] & 0xffff]
-  n = [n[0] >>> 16, n[0] & 0xffff, n[1] >>> 16, n[1] & 0xffff]
+  const m0 = m[0] >>> 16,
+    m1 = m[0] & 0xffff,
+    m2 = m[1] >>> 16,
+    m3 = m[1] & 0xffff
+
+  const n0 = n[0] >>> 16,
+    n1 = n[0] & 0xffff,
+    n2 = n[1] >>> 16,
+    n3 = n[1] & 0xffff
+
   let o0 = 0,
     o1 = 0,
     o2 = 0,
     o3 = 0
-  o3 += m[3] + n[3]
+  o3 += m3 + n3
   o2 += o3 >>> 16
   o3 &= 0xffff
-  o2 += m[2] + n[2]
+  o2 += m2 + n2
   o1 += o2 >>> 16
   o2 &= 0xffff
-  o1 += m[1] + n[1]
+  o1 += m1 + n1
   o0 += o1 >>> 16
   o1 &= 0xffff
-  o0 += m[0] + n[0]
+  o0 += m0 + n0
   o0 &= 0xffff
-  return [(o0 << 16) | o1, (o2 << 16) | o3]
+
+  m[0] = (o0 << 16) | o1
+  m[1] = (o2 << 16) | o3
+  return m
 }
 
 /**
@@ -107,25 +118,31 @@ function x64LeftShift(m: number[], bits: number): void {
     m[1] = 0
   }
 }
-//
-// Given two 64bit ints (as an array of two 32bit ints) returns the two
-// xored together as a 64bit int (as an array of two 32bit ints).
-//
-function x64Xor(m: number[], n: number[]) {
-  return [m[0] ^ n[0], m[1] ^ n[1]]
+/**
+ * Provides a XOR of the given int64 values(provided as tuple of two int32).
+ * Result is written back to the first value
+ */
+function x64Xor(m: number[], n: number[]): void {
+  m[0] = m[0] ^ n[0]
+  m[1] = m[1] ^ n[1]
 }
-//
-// Given a block, returns murmurHash3's final x64 mix of that block.
-// (`[0, h[0] >>> 1]` is a 33 bit unsigned right shift. This is the
-// only place where we need to right shift 64bit ints.)
-//
-function x64Fmix(h: number[]) {
-  h = x64Xor(h, [0, h[0] >>> 1])
-  x64Multiply(h, [0xff51afd7, 0xed558ccd])
-  h = x64Xor(h, [0, h[0] >>> 1])
-  x64Multiply(h, [0xc4ceb9fe, 0x1a85ec53])
-  h = x64Xor(h, [0, h[0] >>> 1])
-  return h
+
+const f1 = [0xff51afd7, 0xed558ccd]
+const f2 = [0xc4ceb9fe, 0x1a85ec53]
+/**
+ * Calculates murmurHash3's final x64 mix of that block and writes result back to the input value.
+ * (`[0, h[0] >>> 1]` is a 33 bit unsigned right shift. This is the
+ * only place where we need to right shift 64bit ints.)
+ */
+function x64Fmix(h: number[]): void {
+  const shifted = [0, h[0] >>> 1]
+  x64Xor(h, shifted)
+  x64Multiply(h, f1)
+  shifted[1] = h[0] >>> 1
+  x64Xor(h, shifted)
+  x64Multiply(h, f2)
+  shifted[1] = h[0] >>> 1
+  x64Xor(h, shifted)
 }
 
 function encode(text: string): Uint8Array {
@@ -168,12 +185,13 @@ function getUTF8Bytes(input: string) {
 export function x64hash128(input: string, seed?: number): string {
   const key = getUTF8Bytes(input)
   seed = seed || 0
-  const remainder = key.length % 16
-  const bytes = key.length - remainder
-  let h1 = [0, seed]
-  let h2 = [0, seed]
-  let k1 = [0, 0]
-  let k2 = [0, 0]
+  const length = [0, key.length]
+  const remainder = length[1] % 16
+  const bytes = length[1] - remainder
+  const h1 = [0, seed]
+  const h2 = [0, seed]
+  const k1 = [0, 0]
+  const k2 = [0, 0]
   const c1 = [0x87c37b91, 0x114253d5]
   const c2 = [0x4cf5ad43, 0x2745937f]
   const m = [0, 5]
@@ -189,19 +207,19 @@ export function x64hash128(input: string, seed?: number): string {
     x64Multiply(k1, c1)
     x64Rotl(k1, 31)
     x64Multiply(k1, c2)
-    h1 = x64Xor(h1, k1)
+    x64Xor(h1, k1)
     x64Rotl(h1, 27)
-    h1 = x64Add(h1, h2)
+    x64Add(h1, h2)
     x64Multiply(h1, m)
-    h1 = x64Add(h1, n1)
+    x64Add(h1, n1)
     x64Multiply(k2, c2)
     x64Rotl(k2, 33)
     x64Multiply(k2, c1)
-    h2 = x64Xor(h2, k2)
+    x64Xor(h2, k2)
     x64Rotl(h2, 31)
-    h2 = x64Add(h2, h1)
+    x64Add(h2, h1)
     x64Multiply(h2, m)
-    h2 = x64Add(h2, n2)
+    x64Add(h2, n2)
   }
   k1[0] = 0
   k1[1] = 0
@@ -212,91 +230,95 @@ export function x64hash128(input: string, seed?: number): string {
     case 15:
       val[1] = key[i + 14]
       x64LeftShift(val, 48)
-      k2 = x64Xor(k2, val)
+      x64Xor(k2, val)
     // fallthrough
     case 14:
       val[1] = key[i + 13]
       x64LeftShift(val, 40)
-      k2 = x64Xor(k2, val)
+      x64Xor(k2, val)
     // fallthrough
     case 13:
       val[1] = key[i + 12]
       x64LeftShift(val, 32)
-      k2 = x64Xor(k2, val)
+      x64Xor(k2, val)
     // fallthrough
     case 12:
       val[1] = key[i + 11]
       x64LeftShift(val, 24)
-      k2 = x64Xor(k2, val)
+      x64Xor(k2, val)
     // fallthrough
     case 11:
       val[1] = key[i + 10]
       x64LeftShift(val, 16)
-      k2 = x64Xor(k2, val)
+      x64Xor(k2, val)
     // fallthrough
     case 10:
       val[1] = key[i + 9]
       x64LeftShift(val, 8)
-      k2 = x64Xor(k2, val)
+      x64Xor(k2, val)
     // fallthrough
     case 9:
-      k2 = x64Xor(k2, [0, key[i + 8]])
+      val[1] = key[i + 8]
+
+      x64Xor(k2, val)
       x64Multiply(k2, c2)
       x64Rotl(k2, 33)
       x64Multiply(k2, c1)
-      h2 = x64Xor(h2, k2)
+      x64Xor(h2, k2)
     // fallthrough
     case 8:
       val[1] = key[i + 7]
       x64LeftShift(val, 56)
-      k1 = x64Xor(k1, val)
+      x64Xor(k1, val)
     // fallthrough
     case 7:
       val[1] = key[i + 6]
       x64LeftShift(val, 48)
-      k1 = x64Xor(k1, val)
+      x64Xor(k1, val)
     // fallthrough
     case 6:
       val[1] = key[i + 5]
       x64LeftShift(val, 40)
-      k1 = x64Xor(k1, val)
+      x64Xor(k1, val)
     // fallthrough
     case 5:
       val[1] = key[i + 4]
       x64LeftShift(val, 32)
-      k1 = x64Xor(k1, val)
+      x64Xor(k1, val)
     // fallthrough
     case 4:
       val[1] = key[i + 3]
       x64LeftShift(val, 24)
-      k1 = x64Xor(k1, val)
+      x64Xor(k1, val)
     // fallthrough
     case 3:
       val[1] = key[i + 2]
       x64LeftShift(val, 16)
-      k1 = x64Xor(k1, val)
+      x64Xor(k1, val)
     // fallthrough
     case 2:
       val[1] = key[i + 1]
       x64LeftShift(val, 8)
-      k1 = x64Xor(k1, val)
+      x64Xor(k1, val)
     // fallthrough
     case 1:
-      k1 = x64Xor(k1, [0, key[i]])
+      val[1] = key[i]
+
+      x64Xor(k1, val)
       x64Multiply(k1, c1)
       x64Rotl(k1, 31)
       x64Multiply(k1, c2)
-      h1 = x64Xor(h1, k1)
+      x64Xor(h1, k1)
     // fallthrough
   }
-  h1 = x64Xor(h1, [0, key.length])
-  h2 = x64Xor(h2, [0, key.length])
-  h1 = x64Add(h1, h2)
-  h2 = x64Add(h2, h1)
-  h1 = x64Fmix(h1)
-  h2 = x64Fmix(h2)
-  h1 = x64Add(h1, h2)
-  h2 = x64Add(h2, h1)
+  x64Xor(h1, length)
+  x64Xor(h2, length)
+  x64Add(h1, h2)
+  x64Add(h2, h1)
+  x64Fmix(h1)
+  x64Fmix(h2)
+  x64Add(h1, h2)
+  x64Add(h2, h1)
   return (
     ('00000000' + (h1[0] >>> 0).toString(16)).slice(-8) +
     ('00000000' + (h1[1] >>> 0).toString(16)).slice(-8) +

--- a/src/utils/hashing.ts
+++ b/src/utils/hashing.ts
@@ -154,6 +154,9 @@ const N2 = [0, 0x38495ab5]
 /**
  * Given a string and an optional seed as an int, returns a 128 bit
  * hash using the x64 flavor of MurmurHash3, as an unsigned hex.
+ * All internal functions mutates passed value to achieve minimal memory allocations and GC load
+ *
+ * Benchmark https://jsbench.me/p4lkpaoabi/1
  */
 export function x64hash128(input: string, seed?: number): string {
   const key = getUTF8Bytes(input)

--- a/src/utils/hashing.ts
+++ b/src/utils/hashing.ts
@@ -8,7 +8,7 @@ import { getUTF8Bytes } from './data'
  * Adds two 64-bit values (provided as tuples of 32-bit values)
  * and updates (mutates) first value to write the result
  */
-function x64Add(m: number[], n: number[]) {
+function x64Add(m: number[], n: number[]): void {
   const m0 = m[0] >>> 16,
     m1 = m[0] & 0xffff,
     m2 = m[1] >>> 16,
@@ -37,7 +37,6 @@ function x64Add(m: number[], n: number[]) {
 
   m[0] = (o0 << 16) | o1
   m[1] = (o2 << 16) | o3
-  return m
 }
 
 /**


### PR DESCRIPTION
I added proper support for non-ASCII symbols for `murmurhash3_128_x64`. Previous implementation wasn't compatible with implementation in other languages (e.g. Golang, C++) for symbols with charcodes outside of `0 - 0xff` range. Also it was limited in terms of uniqueness, e.g. `hash('Hello, world, hi')` was equal to `hash('ňťŬŬůĬĠŷůŲŬŤĬĠŨũ')`.
Current new implementation are free of these issues

Also I refactored internal functions to achieve minimal minimal memory allocations and reduce GC load, it gained performance boost: 
* Chrome: 27%
* Webkit: 58%
* Firefox: 45%

[Benchmark](https://jsbench.me/p4lkpaoabi/1) (sorry for the minified code in the benchmark, `jsbench` allows to save suite only if fields are below 2048 symbols, so I tried to make it more compact)

<details>
  <summary>JSBench screenshots</summary>

<img width="207" alt="image" src="https://github.com/fingerprintjs/fingerprintjs/assets/21976058/050e5bb5-d265-4d76-9065-98bb8f75f23b">

Webkit

<img width="203" alt="image" src="https://github.com/fingerprintjs/fingerprintjs/assets/21976058/dd985cda-4c32-4801-a804-923395253873">

Chrome

<img width="199" alt="image" src="https://github.com/fingerprintjs/fingerprintjs/assets/21976058/e4c87907-05ca-4a68-8137-2cce8275eaf5">

Firefox
</details>