### PR TITLE
Update Rollup to resolve a console warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "karma-typescript": "^5.5.3",
     "prettier": "^2.7.1",
     "rimraf": "^3.0.2",
-    "rollup": "^3.3.0",
+    "rollup": "^3.25.0",
     "rollup-plugin-dts": "^5.3.1",
     "rollup-plugin-license": "^3.0.1",
     "terser-webpack-plugin": "^5.3.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4170,10 +4170,10 @@ rollup-plugin-license@^3.0.1:
     spdx-expression-validate "~2.0.0"
     spdx-satisfies "~5.0.1"
 
-rollup@^3.3.0:
-  version "3.8.1"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-3.8.1.tgz#d4af8aca7c60d5b8c0281be79ea2fab6b41d458f"
-  integrity sha512-4yh9eMW7byOroYcN8DlF9P/2jCpu6txVIHjEqquQVSx7DI0RgyCCN3tjrcy4ra6yVtV336aLBB3v2AarYAxePQ==
+rollup@^3.25.0:
+  version "3.28.1"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-3.28.1.tgz#fb44aa6d5e65c7e13fd5bcfff266d0c4ea9ba433"
+  integrity sha512-R9OMQmIHJm9znrU3m3cpE8uhN0fGdXiawME7aZIpQqvpS/85+Vt1Hq1/yVIcYfOmaQiHjvXkQAoJukvLpau6Yw==
   optionalDependencies:
     fsevents "~2.3.2"
 


### PR DESCRIPTION
I noticed that our build script [emits a warning](https://github.com/fingerprintjs/fingerprintjs/actions/runs/5865216560/job/15901702124#step:6:16). This was broken by #932. This PR fixes it.