### PR TITLE
Remove unnecessary error handling in Node.js scripts

### DIFF
--- a/resources/content_blocking/get_unique_filter_selectors.ts
+++ b/resources/content_blocking/get_unique_filter_selectors.ts
@@ -10,6 +10,8 @@ import { eachLineInFile } from './utils'
 const inputDirectory = path.join(__dirname, 'blocked_selectors')
 const outputFile = path.join(__dirname, 'unique_filter_selectors.json')
 
+run()
+
 async function run() {
   const filterSelectors = await getUniqueFilterSelectors(inputDirectory)
   await fsAsync.writeFile(outputFile, stringifyResult(filterSelectors))
@@ -148,9 +150,3 @@ function print(message: string) {
   // eslint-disable-next-line no-console
   console.log(message)
 }
-
-run().catch((error) => {
-  // eslint-disable-next-line no-console
-  console.error(error)
-  process.exitCode = 1
-})

--- a/resources/content_blocking/insert_filter_code.ts
+++ b/resources/content_blocking/insert_filter_code.ts
@@ -15,6 +15,8 @@ const filterCodeRegex = /(\n(?:export )?function getFilters\(\)(?:: [\w<>,\s]+)?
 
 type Filters = Record<string, string[]>
 
+run()
+
 async function run() {
   const [uniqueSelectors, currentFilters] = await Promise.all([
     fsAsync.readFile(uniqueSelectorsFile, 'utf8').then<Filters>(JSON.parse),
@@ -119,9 +121,3 @@ function isInappropriateSelector(selector: string) {
 
   return probes.some((probe) => probe.test(selector))
 }
-
-run().catch((error) => {
-  // eslint-disable-next-line no-console
-  console.error(error)
-  process.exitCode = 1
-})

--- a/resources/content_blocking/make_selectors_tester.ts
+++ b/resources/content_blocking/make_selectors_tester.ts
@@ -12,6 +12,8 @@ import { fetchFilter } from './utils'
 const inputScript = path.join(__dirname, 'selectors_tester.ts')
 const outputFile = path.join(__dirname, 'selectors_tester.html')
 
+run()
+
 async function run() {
   const uniqueSelectors = await fetchUniqueSelectors(filterConfig)
   const testerHtml = await makeTesterHtml(uniqueSelectors)
@@ -115,9 +117,3 @@ async function getJsToDetectBlockedSelectors(selectors: readonly string[]) {
   })
   return output[0].code.replace(/\[\s*\/\*\s*selectors\s*\*\/\s*]/g, JSON.stringify(selectors))
 }
-
-run().catch((error) => {
-  // eslint-disable-next-line no-console
-  console.error(error)
-  process.exitCode = 1
-})


### PR DESCRIPTION
Node.js stop the process with exit code 1 on unhandled promise rejection automatically [since version 15](https://nodejs.org/en/blog/release/v15.0.0#throw-on-unhandled-rejections---33021), so the `catch` handlers in the scripts aren't needed anymore.