### PR TITLE
Turn off tampered entropy sources in Safari 17

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ export const murmurX64Hash128 = x64hash128
 export { prepareForSources } from './agent'
 export { sources } from './sources'
 export { getRawScreenFrame } from './sources/screen_frame'
+export { getRawScreenResolution } from './sources/screen_resolution'
 export { getStateFromError as handleApplePayError } from './sources/apple_pay'
 export { getWebGLContext } from './sources/webgl'
 export {

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ export const murmurX64Hash128 = x64hash128
 export { prepareForSources } from './agent'
 export { sources } from './sources'
 export { getRawAudioFingerprint } from './sources/audio'
+export { getRawCanvasFingerprint } from './sources/canvas'
 export { getRawScreenFrame } from './sources/screen_frame'
 export { getRawScreenResolution } from './sources/screen_resolution'
 export { getStateFromError as handleApplePayError } from './sources/apple_pay'

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,7 @@ export default { load, hashComponents, componentsToDebugString }
 export const murmurX64Hash128 = x64hash128
 export { prepareForSources } from './agent'
 export { sources } from './sources'
-export { getScreenFrame } from './sources/screen_frame'
+export { getRawScreenFrame } from './sources/screen_frame'
 export { getStateFromError as handleApplePayError } from './sources/apple_pay'
 export { getWebGLContext } from './sources/webgl'
 export {

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,7 @@ export default { load, hashComponents, componentsToDebugString }
 export const murmurX64Hash128 = x64hash128
 export { prepareForSources } from './agent'
 export { sources } from './sources'
+export { getRawAudioFingerprint } from './sources/audio'
 export { getRawScreenFrame } from './sources/screen_frame'
 export { getRawScreenResolution } from './sources/screen_resolution'
 export { getStateFromError as handleApplePayError } from './sources/apple_pay'

--- a/src/sources/audio.test.ts
+++ b/src/sources/audio.test.ts
@@ -6,8 +6,10 @@ describe('Sources', () => {
     it('returns expected value type depending on the browser', async () => {
       const result = getAudioFingerprint()
 
-      if (isUnsupportedBrowser()) {
-        expect(result).toBe(SpecialFingerprint.KnownToSuspend)
+      if (isAntifingerprintingBrowser()) {
+        expect(result).toBe(SpecialFingerprint.KnownForAntifingerprinting)
+      } else if (isSuspendingBrowser()) {
+        expect(result).toBe(SpecialFingerprint.KnownForSuspending)
       } else {
         // A type guard
         if (typeof result !== 'function') {
@@ -21,12 +23,12 @@ describe('Sources', () => {
     })
 
     it('returns a stable value', async () => {
-      if (isUnsupportedBrowser()) {
-        return
-      }
-
       const first = getAudioFingerprint()
       const second = getAudioFingerprint()
+
+      if (first === second) {
+        return
+      }
 
       if (typeof first !== 'function' || typeof second !== 'function') {
         throw new Error('Expected to be a function')
@@ -37,7 +39,11 @@ describe('Sources', () => {
   })
 })
 
-function isUnsupportedBrowser() {
+function isAntifingerprintingBrowser() {
+  return isSafari() && (getBrowserMajorVersion() ?? 0) >= 17
+}
+
+function isSuspendingBrowser() {
   // WebKit has stopped telling its real version in the user-agent string since version 605.1.15,
   // therefore the browser version has to be checked instead of the engine version.
   return isSafari() && isMobile() && (getBrowserMajorVersion() ?? 0) < 12

--- a/src/sources/audio.test.ts
+++ b/src/sources/audio.test.ts
@@ -6,9 +6,9 @@ describe('Sources', () => {
     it('returns expected value type depending on the browser', async () => {
       const result = getAudioFingerprint()
 
-      if (isAntifingerprintingBrowser()) {
+      if (doesBrowserPerformAntifingerprinting()) {
         expect(result).toBe(SpecialFingerprint.KnownForAntifingerprinting)
-      } else if (isSuspendingBrowser()) {
+      } else if (doesBrowserSuspendAudioContext()) {
         expect(result).toBe(SpecialFingerprint.KnownForSuspending)
       } else {
         // A type guard
@@ -39,11 +39,11 @@ describe('Sources', () => {
   })
 })
 
-function isAntifingerprintingBrowser() {
+function doesBrowserPerformAntifingerprinting() {
   return isSafari() && (getBrowserMajorVersion() ?? 0) >= 17
 }
 
-function isSuspendingBrowser() {
+function doesBrowserSuspendAudioContext() {
   // WebKit has stopped telling its real version in the user-agent string since version 605.1.15,
   // therefore the browser version has to be checked instead of the engine version.
   return isSafari() && isMobile() && (getBrowserMajorVersion() ?? 0) < 12

--- a/src/sources/audio.ts
+++ b/src/sources/audio.ts
@@ -22,10 +22,10 @@ const enum InnerErrorName {
  * Inspired by and based on https://github.com/cozylife/audio-fingerprint
  *
  * A version of the entropy source with stabilization to make it suitable for static fingerprinting.
- * Audio signal is noised in private mode of Safari 17.
+ * Audio signal is noised in private mode of Safari 17, so audio fingerprinting is skipped in Safari 17.
  */
 export default function getAudioFingerprint(): number | (() => Promise<number>) {
-  if (doesCurrentBrowserPerformAntifingerprinting()) {
+  if (doesBrowserPerformAntifingerprinting()) {
     return SpecialFingerprint.KnownForAntifingerprinting
   }
 
@@ -49,7 +49,7 @@ export function getRawAudioFingerprint(): number | (() => Promise<number>) {
   // (e.g. a click or a tap). It prevents audio fingerprint from being taken at an arbitrary moment of time.
   // Such browsers are old and unpopular, so the audio fingerprinting is just skipped in them.
   // See a similar case explanation at https://stackoverflow.com/questions/46363048/onaudioprocess-not-called-on-ios11#46534088
-  if (doesCurrentBrowserSuspendAudioContext()) {
+  if (doesBrowserSuspendAudioContext()) {
     return SpecialFingerprint.KnownForSuspending
   }
 
@@ -95,7 +95,7 @@ export function getRawAudioFingerprint(): number | (() => Promise<number>) {
 /**
  * Checks if the current browser is known for always suspending audio context
  */
-function doesCurrentBrowserSuspendAudioContext() {
+function doesBrowserSuspendAudioContext() {
   // Mobile Safari 11 and older
   return isWebKit() && !isDesktopSafari() && !isWebKit606OrNewer()
 }
@@ -103,7 +103,7 @@ function doesCurrentBrowserSuspendAudioContext() {
 /**
  * Checks if the current browser is known for applying anti-fingerprinting measures in all or some critical modes
  */
-function doesCurrentBrowserPerformAntifingerprinting() {
+function doesBrowserPerformAntifingerprinting() {
   // Safari 17
   return isWebKit() && isWebKit616OrNewer()
 }

--- a/src/sources/canvas.test.ts
+++ b/src/sources/canvas.test.ts
@@ -1,21 +1,36 @@
-import getCanvasFingerprint from './canvas'
+import { getBrowserMajorVersion, isSafari } from '../../tests/utils'
+import getCanvasFingerprint, { ImageStatus } from './canvas'
 
 describe('Sources', () => {
   describe('canvas', () => {
+    it('returns expected value', async () => {
+      const { winding, text, geometry } = await getCanvasFingerprint()
+
+      expect(winding).toBeTrue()
+
+      if (shouldSkip()) {
+        expect(text).toBe(ImageStatus.Skipped)
+        expect(geometry).toBe(ImageStatus.Skipped)
+      } else {
+        expect(isDataURL(geometry)).toBeTrue()
+        expect(isDataURL(text)).toBeTrue()
+
+        expect(geometry.length).toBeGreaterThan(1000)
+        expect(text.length).toBeGreaterThan(1000)
+      }
+    })
+
     it('returns stable values', async () => {
       const first = await getCanvasFingerprint()
       const second = await getCanvasFingerprint()
-
-      expect(isDataURL(first.geometry)).toBeTrue()
-      expect(isDataURL(first.text)).toBeTrue()
-
-      expect(first.geometry.length).toBeGreaterThan(1000)
-      expect(first.text.length).toBeGreaterThan(1000)
-
       expect(second).toEqual(first)
     })
   })
 })
+
+function shouldSkip() {
+  return isSafari() && (getBrowserMajorVersion() ?? 0) >= 17
+}
 
 function isDataURL(url: string) {
   return /^data:image\/png;base64,([0-9a-zA-Z+/]{4})*(([0-9a-zA-Z+/]{2}==)|([0-9a-zA-Z+/]{3}=))?$/.test(url)

--- a/src/sources/index.ts
+++ b/src/sources/index.ts
@@ -9,7 +9,7 @@ import getLanguages from './languages'
 import getColorDepth from './color_depth'
 import getDeviceMemory from './device_memory'
 import getScreenResolution from './screen_resolution'
-import { getRoundedScreenFrame } from './screen_frame'
+import getScreenFrame from './screen_frame'
 import getHardwareConcurrency from './hardware_concurrency'
 import getTimezone from './timezone'
 import getSessionStorage from './session_storage'
@@ -57,7 +57,7 @@ export const sources = {
   domBlockers: getDomBlockers,
   fontPreferences: getFontPreferences,
   audio: getAudioFingerprint,
-  screenFrame: getRoundedScreenFrame,
+  screenFrame: getScreenFrame,
   canvas: getCanvasFingerprint,
 
   osCpu: getOsCpu,

--- a/src/sources/screen_frame.ts
+++ b/src/sources/screen_frame.ts
@@ -96,7 +96,7 @@ export function getRawScreenFrame(): () => Promise<FrameSize> {
  * Sometimes the available screen resolution changes a bit, e.g. 1900x1440 → 1900x1439. A possible reason: macOS Dock
  * shrinks to fit more icons when there is too little space. The rounding is used to mitigate the difference.
  *
- * The frame width is always 0 in private mode of Safari 17.
+ * The frame width is always 0 in private mode of Safari 17, so the frame is not used in Safari 17.
  */
 export default function getScreenFrame(): () => Promise<FrameSize | undefined> {
   if (isWebKit() && isWebKit616OrNewer()) {

--- a/src/sources/screen_frame.ts
+++ b/src/sources/screen_frame.ts
@@ -1,5 +1,5 @@
 import { replaceNaN, round, toFloat } from '../utils/data'
-import { exitFullscreen, getFullscreenElement } from '../utils/browser'
+import { exitFullscreen, getFullscreenElement, isWebKit, isWebKit616OrNewer } from '../utils/browser'
 
 /**
  * The order matches the CSS side order: top, right, bottom, left.
@@ -57,10 +57,12 @@ export function hasScreenFrameBackup(): boolean {
 }
 
 /**
+ * A version of the entropy source without stabilization.
+ *
  * Warning for package users:
  * This function is out of Semantic Versioning, i.e. can change unexpectedly. Usage is at your own risk.
  */
-export function getScreenFrame(): () => Promise<FrameSize> {
+export function getRawScreenFrame(): () => Promise<FrameSize> {
   watchScreenFrame()
 
   return async () => {
@@ -89,11 +91,19 @@ export function getScreenFrame(): () => Promise<FrameSize> {
 }
 
 /**
+ * A version of the entropy source with stabilization to make it suitable for static fingerprinting.
+ *
  * Sometimes the available screen resolution changes a bit, e.g. 1900x1440 → 1900x1439. A possible reason: macOS Dock
  * shrinks to fit more icons when there is too little space. The rounding is used to mitigate the difference.
+ *
+ * The frame width is always 0 in private mode of Safari 17.
  */
-export function getRoundedScreenFrame(): () => Promise<FrameSize> {
-  const screenFrameGetter = getScreenFrame()
+export default function getScreenFrame(): () => Promise<FrameSize | undefined> {
+  if (isWebKit() && isWebKit616OrNewer()) {
+    return () => Promise.resolve(undefined)
+  }
+
+  const screenFrameGetter = getRawScreenFrame()
 
   return async () => {
     const frameSize = await screenFrameGetter()

--- a/src/sources/screen_resolution.test.ts
+++ b/src/sources/screen_resolution.test.ts
@@ -1,3 +1,4 @@
+import { getBrowserMajorVersion, isSafari } from '../../tests/utils'
 import getScreenResolution from './screen_resolution'
 
 describe('Sources', () => {
@@ -5,6 +6,14 @@ describe('Sources', () => {
     it('handles browser native value', () => {
       const result = getScreenResolution()
 
+      if (shouldTurnOff()) {
+        expect(result).toBeUndefined()
+        return
+      }
+
+      if (result === undefined) {
+        throw new Error('Expected not to be undefined')
+      }
       expect(result[0]).toBeGreaterThan(0)
       expect(result[1]).toBeGreaterThan(0)
     })
@@ -17,3 +26,7 @@ describe('Sources', () => {
     })
   })
 })
+
+function shouldTurnOff() {
+  return isSafari() && (getBrowserMajorVersion() ?? 0) >= 17
+}

--- a/src/sources/screen_resolution.ts
+++ b/src/sources/screen_resolution.ts
@@ -1,13 +1,34 @@
 import { replaceNaN, toInt } from '../utils/data'
+import { isWebKit, isWebKit616OrNewer } from '../utils/browser'
 
-export default function getScreenResolution(): [number | null, number | null] {
+type ScreenResolution = [number | null, number | null]
+
+/**
+ * A version of the entropy source with stabilization to make it suitable for static fingerprinting.
+ * The window resolution is always the document size in private mode of Safari 17.
+ */
+export default function getScreenResolution(): ScreenResolution | undefined {
+  if (isWebKit() && isWebKit616OrNewer()) {
+    return undefined
+  }
+
+  return getRawScreenResolution()
+}
+
+/**
+ * A version of the entropy source without stabilization.
+ *
+ * Warning for package users:
+ * This function is out of Semantic Versioning, i.e. can change unexpectedly. Usage is at your own risk.
+ */
+export function getRawScreenResolution(): ScreenResolution {
   const s = screen
 
   // Some browsers return screen resolution as strings, e.g. "1200", instead of a number, e.g. 1200.
   // I suspect it's done by certain plugins that randomize browser properties to prevent fingerprinting.
   // Some browsers even return  screen resolution as not numbers.
   const parseDimension = (value: unknown) => replaceNaN(toInt(value), null)
-  const dimensions = [parseDimension(s.width), parseDimension(s.height)] as [number | null, number | null]
+  const dimensions = [parseDimension(s.width), parseDimension(s.height)] as ScreenResolution
   dimensions.sort().reverse()
   return dimensions
 }

--- a/src/sources/screen_resolution.ts
+++ b/src/sources/screen_resolution.ts
@@ -5,7 +5,8 @@ type ScreenResolution = [number | null, number | null]
 
 /**
  * A version of the entropy source with stabilization to make it suitable for static fingerprinting.
- * The window resolution is always the document size in private mode of Safari 17.
+ * The window resolution is always the document size in private mode of Safari 17,
+ * so the window resolution is not used in Safari 17.
  */
 export default function getScreenResolution(): ScreenResolution | undefined {
   if (isWebKit() && isWebKit616OrNewer()) {

--- a/src/utils/browser.ts
+++ b/src/utils/browser.ts
@@ -160,7 +160,7 @@ export function isChromium86OrNewer(): boolean {
  * @see https://en.wikipedia.org/wiki/Safari_version_history#Release_history Safari-WebKit versions map
  */
 export function isWebKit606OrNewer(): boolean {
-  // Checked in Safari 9–14
+  // Checked in Safari 9–17
   const w = window
 
   return (
@@ -202,10 +202,10 @@ export function isWebKit616OrNewer(): boolean {
  */
 export function isIPad(): boolean {
   // Checked on:
-  // Safari on iPadOS (both mobile and desktop modes): 8, 11, 12, 13, 14
-  // Chrome on iPadOS (both mobile and desktop modes): 11, 12, 13, 14
-  // Safari on iOS (both mobile and desktop modes): 9, 10, 11, 12, 13, 14
-  // Chrome on iOS (both mobile and desktop modes): 9, 10, 11, 12, 13, 14
+  // Safari on iPadOS (both mobile and desktop modes): 8, 11-17
+  // Chrome on iPadOS (both mobile and desktop modes): 11-17
+  // Safari on iOS (both mobile and desktop modes): 9-17
+  // Chrome on iOS (both mobile and desktop modes): 9-17
 
   // Before iOS 13. Safari tampers the value in "request desktop site" mode since iOS 13.
   if (navigator.platform === 'iPad') {
@@ -219,7 +219,7 @@ export function isIPad(): boolean {
     countTruthy([
       'MediaSource' in window, // Since iOS 13
       !!Element.prototype.webkitRequestFullscreen, // Since iOS 12
-      // iPhone 4S that runs iOS 9 matches this. But it won't match the criteria above, so it won't be detected as iPad.
+      // iPhone 4S that runs iOS 9 matches this, but it is not supported
       screenRatio > 0.65 && screenRatio < 1.53,
     ]) >= 2
   )


### PR DESCRIPTION
Safari 17 introduces anti-fingerprinting measures in private mode. They affect the following entropy sources:

- `screenResolution`
- `screenFrame`
- `audio`
- `canvas`

The fingerprint components are modified in private mode, which makes FingerprintJS produce different fingerprints.

Unfortunately, I have to disable the entropy sources in Safari 17 now, because, there is no apparent way to restore the original components, and iOS 17 will be published on September 18th. It will make FingerprintJS produce the same fingerprint in regular and incognito modes of Safari 17. We keep looking for ways to get stable entropy from these sources.