### PR TITLE
Add "Reduced transparency" entropy source

### DIFF
--- a/src/sources/index.ts
+++ b/src/sources/index.ts
@@ -28,6 +28,7 @@ import areColorsForced from './forced_colors'
 import getMonochromeDepth from './monochrome'
 import getContrastPreference from './contrast'
 import isMotionReduced from './reduced_motion'
+import isTransparencyReduced from './reduced_transparency'
 import isHDR from './hdr'
 import getMathFingerprint from './math'
 import getFontPreferences from './font_preferences'
@@ -84,6 +85,7 @@ export const sources = {
   monochrome: getMonochromeDepth,
   contrast: getContrastPreference,
   reducedMotion: isMotionReduced,
+  reducedTransparency: isTransparencyReduced,
   hdr: isHDR,
   math: getMathFingerprint,
   pdfViewerEnabled: isPdfViewerEnabled,

--- a/src/sources/reduced_transparency.test.ts
+++ b/src/sources/reduced_transparency.test.ts
@@ -1,0 +1,22 @@
+import { withMockMatchMedia } from '../../tests/utils'
+import isTransparencyReduced from './reduced_transparency'
+
+describe('Sources', () => {
+  describe('reducedTransparency', () => {
+    it('handles browser native value', () => {
+      expect([undefined, true, false]).toContain(isTransparencyReduced())
+    })
+
+    it('handles various cases', async () => {
+      await withMockMatchMedia({ 'prefers-reduced-transparency': [undefined] }, true, () =>
+        expect(isTransparencyReduced()).toBeUndefined(),
+      )
+      await withMockMatchMedia({ 'prefers-reduced-transparency': ['no-preference'] }, true, () =>
+        expect(isTransparencyReduced()).toBeFalse(),
+      )
+      await withMockMatchMedia({ 'prefers-reduced-transparency': ['reduce'] }, true, () =>
+        expect(isTransparencyReduced()).toBeTrue(),
+      )
+    })
+  })
+})

--- a/src/sources/reduced_transparency.ts
+++ b/src/sources/reduced_transparency.ts
@@ -1,0 +1,16 @@
+/**
+ * @see https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-transparency
+ */
+export default function isTransparencyReduced(): boolean | undefined {
+  if (doesMatch('reduce')) {
+    return true
+  }
+  if (doesMatch('no-preference')) {
+    return false
+  }
+  return undefined
+}
+
+function doesMatch(value: string) {
+  return matchMedia(`(prefers-reduced-transparency: ${value})`).matches
+}


### PR DESCRIPTION
Chrome 118 and Firefox 118 on macOS 14.1 and Windows 10 reflect the transparency selection in the OS settings. Firefox requires the `layout.css.prefers-reduced-transparency.enabled` feature flag to be enabled in `about:config` (it won't be required in future). Safari 14–17 don’t support the feature.