### PR TITLE
fix: Replace android notification detector

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fingerprintjs/fingerprintjs",
   "description": "Browser fingerprinting library with the highest accuracy and stability",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "keywords": [
     "fraud",
     "fraud detection",

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -15,6 +15,9 @@ interface Navigator {
   deviceMemory?: number
   cpuClass?: string
   readonly msMaxTouchPoints?: number
+  connection?: {
+    ontypechange?: () => void
+  }
 }
 
 interface Document {

--- a/src/utils/browser.ts
+++ b/src/utils/browser.ts
@@ -293,6 +293,7 @@ export function isAndroid(): boolean {
         !('SharedWorker' in w),
         // `typechange` is deprecated, but it's still present on Android (tested on Chrome Mobile 117)
         // Removal proposal https://bugs.chromium.org/p/chromium/issues/detail?id=699892
+        // Note: this expression returns true on ChromeOS, so additional detectors are required to avoid false-positives
         n[c] && 'ontypechange' in n[c],
         !('sinkId' in new window.Audio()),
       ]) >= 2


### PR DESCRIPTION
Addresses https://github.com/fingerprintjs/fingerprintjs/issues/968

Detector based on `Notification` constuctor was replaced with `ontypechange` check.

Though this particular method returns `true` on Chromebook with latest Chrome browser, the other detectors return `false` which makes the total result stable