### PR TITLE
fix: WebGL console warning in Chrome 121 and Safari 17.4

### DIFF
--- a/src/sources/webgl.ts
+++ b/src/sources/webgl.ts
@@ -1,4 +1,4 @@
-import { isGecko } from '../utils/browser'
+import { isChromium, isGecko, isWebKit } from '../utils/browser'
 
 // Types and constants are used instead of interfaces and enums to avoid this error in projects which use this library:
 // Exported variable '...' has or is using name '...' from external module "..." but cannot be named.
@@ -133,8 +133,10 @@ export function getWebGlExtensions({ cache }: Options): WebGlExtensionsPayload |
   // Extension parameters
   if (extensions) {
     for (const name of extensions) {
-      // The "polygon mode" extension causes a console warning in Chromium and WebKit
-      if (name === polygonModeExtensionName || (name === rendererInfoExtensionName && shouldAvoidDebugRendererInfo())) {
+      if (
+        (name === rendererInfoExtensionName && shouldAvoidDebugRendererInfo()) ||
+        (name === polygonModeExtensionName && shouldAvoidPolygonModeExtensions())
+      ) {
         continue
       }
 
@@ -234,6 +236,14 @@ function isConstantLike<K>(key: K): key is Extract<K, string> {
  */
 export function shouldAvoidDebugRendererInfo(): boolean {
   return isGecko()
+}
+
+/**
+ * Some browsers print a console warning when the WEBGL_polygon_mode extension is requested.
+ * JS Agent aims to avoid printing messages to console, so we avoid this extension in that browsers.
+ */
+export function shouldAvoidPolygonModeExtensions(): boolean {
+  return isChromium() || isWebKit()
 }
 
 /**

--- a/src/sources/webgl.ts
+++ b/src/sources/webgl.ts
@@ -67,6 +67,7 @@ const validExtensionParams = new Set([
 const shaderTypes = ['FRAGMENT_SHADER', 'VERTEX_SHADER'] as const
 const precisionTypes = ['LOW_FLOAT', 'MEDIUM_FLOAT', 'HIGH_FLOAT', 'LOW_INT', 'MEDIUM_INT', 'HIGH_INT'] as const
 const rendererInfoExtensionName = 'WEBGL_debug_renderer_info'
+const polygonModeExtensionName = 'WEBGL_polygon_mode'
 
 /**
  * Gets the basic and simple WebGL parameters
@@ -132,7 +133,8 @@ export function getWebGlExtensions({ cache }: Options): WebGlExtensionsPayload |
   // Extension parameters
   if (extensions) {
     for (const name of extensions) {
-      if (name === rendererInfoExtensionName && shouldAvoidDebugRendererInfo()) {
+      // The "polygon mode" extension causes a console warning in Chromium and WebKit
+      if (name === polygonModeExtensionName || (name === rendererInfoExtensionName && shouldAvoidDebugRendererInfo())) {
         continue
       }
 


### PR DESCRIPTION
This remove an unwanted console message arising in:

- Blink (Chrome) 121: `webgl.ts:139 WebGL: this extension has very low support on mobile devices; do not rely on it for rendering effects: WEBGL_polygon_mode`
- WebKit (Safari) 17.4: `WebGL: non-portable extension enabled: WEBGL_polygon_mode`

The PR disables the `WEBGL_polygon_mode` extension, but this is not a fingerprint-breaking change, because the extension didn't exist in the previous versions. Though the browser updates change the fingerprint because of other changes to WebGL.