### PR TITLE
chore: Support `yarn build` on Windows machines

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "rimraf dist && rollup -c rollup.config.ts --configPlugin '@rollup/plugin-typescript={tsconfig:`tsconfig.rollupConfig.json`}'",
+    "build": "rimraf dist && rollup -c rollup.config.ts --configPlugin \"@rollup/plugin-typescript={tsconfig:'tsconfig.rollupConfig.json'}\"",
     "build:watch": "yarn build --watch",
     "playground:start": "cd playground && webpack-dev-server --mode development",
     "playground:build": "cd playground && webpack --mode production",


### PR DESCRIPTION
Resolves https://github.com/fingerprintjs/fingerprintjs/issues/981