### PR TITLE
Bugfix: values of canvas geometry and text returned in reverse order.

### DIFF
--- a/src/sources/canvas.ts
+++ b/src/sources/canvas.ts
@@ -94,7 +94,7 @@ async function renderImages(
   renderGeometryImage(canvas, context)
   await releaseEventLoop()
   const geometryImage = canvasToString(canvas)
-  return [textImage1, geometryImage]
+  return [geometryImage, textImage1]
 }
 
 function renderTextImage(canvas: HTMLCanvasElement, context: CanvasRenderingContext2D) {


### PR DESCRIPTION
Values of geometry and text in canvas are reversed. 

The demo site confirms it: https://fingerprintjs.github.io/fingerprintjs/
I copy/paste geometry and text values to https://codebeautify.org/base64-to-image-converter, and can see the images are swapped.