### PR TITLE
Revert audio fingerprint to the version from v4.1.0

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,7 @@ export default { load, hashComponents, componentsToDebugString }
 export const murmurX64Hash128 = x64hash128
 export { prepareForSources } from './agent'
 export { sources } from './sources'
-export { getUnstableAudioFingerprint, doesBrowserSuspendAudioContext, renderAudio } from './sources/audio'
+export { getUnstableAudioFingerprint } from './sources/audio'
 export { getUnstableCanvasFingerprint } from './sources/canvas'
 export { getUnstableScreenFrame } from './sources/screen_frame'
 export { getUnstableScreenResolution } from './sources/screen_resolution'

--- a/src/sources/audio.test.ts
+++ b/src/sources/audio.test.ts
@@ -1,66 +1,47 @@
-import { getBrowserMajorVersion, isChromium, isGecko, isMobile, isSafari, isWebKit } from '../../tests/utils'
-import getAudioFingerprint, { getMiddle, SpecialFingerprint, stabilize } from './audio'
+import { getBrowserMajorVersion, isMobile, isSafari } from '../../tests/utils'
+import getAudioFingerprint, { SpecialFingerprint } from './audio'
 
 describe('Sources', () => {
   describe('audio', () => {
-    it('returns expected value', async () => {
-      const result = (await getAudioFingerprint())()
+    it('returns expected value type depending on the browser', async () => {
+      const result = getAudioFingerprint()
 
-      if (doesBrowserSuspendAudioContext()) {
+      if (doesBrowserPerformAntifingerprinting()) {
+        expect(result).toBe(SpecialFingerprint.KnownForAntifingerprinting)
+      } else if (doesBrowserSuspendAudioContext()) {
         expect(result).toBe(SpecialFingerprint.KnownForSuspending)
-      } else if (isGecko()) {
-        expect(result).toBeGreaterThan(0.000169)
-        expect(result).toBeLessThan(0.00017)
-      } else if (isWebKit()) {
-        if ('OfflineAudioContext' in window) {
-          expect(result).toBeGreaterThan(0.000058)
-          expect(result).toBeLessThan(0.000066)
-        } else {
-          expect(result).toBeGreaterThan(0.000113)
-          expect(result).toBeLessThan(0.000114)
-        }
-      } else if (isChromium()) {
-        expect(result).toBeGreaterThan(0.00006)
-        expect(result).toBeLessThan(0.00009)
       } else {
-        throw new Error('Unexpected browser')
+        // A type guard
+        if (typeof result !== 'function') {
+          throw new Error('Expected to be a function')
+        }
+        const fingerprint = await result()
+        expect(fingerprint).toBeGreaterThanOrEqual(0)
+        const newFingerprint = await result()
+        expect(newFingerprint).toBe(newFingerprint)
       }
     })
 
     it('returns a stable value', async () => {
-      const finishFirst = await getAudioFingerprint()
-      const first = finishFirst()
-      const finishSecond = await getAudioFingerprint()
-      const second = finishSecond()
-      expect(first).toBe(second)
-      expect(finishFirst()).toBe(first)
-    })
-  })
+      const first = getAudioFingerprint()
+      const second = getAudioFingerprint()
 
-  describe('getMiddle helper', () => {
-    it('calculates properly and ignores zeros', () => {
-      const signal = [
-        0, -5.92384345, -3.39578492, -4.39564854, 0, -3.89384529, -8.92384234, -5.01429423, -4.12045834, -3.93298453, 0,
-      ]
-      expect(getMiddle(signal)).toEqual(-6.15981363)
-    })
-  })
+      if (first === second) {
+        return
+      }
 
-  describe('stabilize helper', () => {
-    it('calculates properly', () => {
-      expect(stabilize(0.000123456789, 2)).toBe(0.00012)
-      expect(stabilize(0.000000012345, 2)).toBe(0.000000012)
-      expect(stabilize(-0.000123456789, 2)).toBe(-0.00012)
-      expect(stabilize(0.000123456789, 7)).toBe(0.0001234568)
-      expect(stabilize(0.000123456789, 2.2)).toBe(0.000125)
-      expect(stabilize(0.000123456789, 2.5)).toBe(0.000124)
-      expect(stabilize(0.000123456789, 6.2)).toBe(0.000123457)
-      expect(stabilize(0.000123456789, 15.5)).toBe(0.000123456789)
-      expect(stabilize(0.000123456789, 5.2)).toBe(0.000123455)
-      expect(stabilize(0.000123456789, 5.5)).toBe(0.000123456)
+      if (typeof first !== 'function' || typeof second !== 'function') {
+        throw new Error('Expected to be a function')
+      }
+
+      expect(await second()).toBe(await first())
     })
   })
 })
+
+function doesBrowserPerformAntifingerprinting() {
+  return isSafari() && (getBrowserMajorVersion() ?? 0) >= 17
+}
 
 function doesBrowserSuspendAudioContext() {
   // WebKit has stopped telling its real version in the user-agent string since version 605.1.15,

--- a/src/sources/audio.ts
+++ b/src/sources/audio.ts
@@ -1,6 +1,5 @@
-import { isDesktopWebKit, isWebKit, isWebKit606OrNewer } from '../utils/browser'
-import { isPromise, suppressUnhandledRejectionWarning, wait } from '../utils/async'
-import { whenDocumentVisible } from '../utils/dom'
+import { isDesktopWebKit, isSafariWebKit, isWebKit, isWebKit606OrNewer, isWebKit616OrNewer } from '../utils/browser'
+import { isPromise, suppressUnhandledRejectionWarning } from '../utils/async'
 
 export const enum SpecialFingerprint {
   /** The browser is known for always suspending audio context, thus making fingerprinting impossible */
@@ -9,22 +8,28 @@ export const enum SpecialFingerprint {
   NotSupported = -2,
   /** An unexpected timeout has happened */
   Timeout = -3,
+  /** The browser is known for applying anti-fingerprinting measures in all or some critical modes */
+  KnownForAntifingerprinting = -4,
 }
 
-const sampleRate = 44100
-const cloneCount = 40000
-const stabilizationPrecision = 6.2
+const enum InnerErrorName {
+  Timeout = 'timeout',
+  Suspended = 'suspended',
+}
 
 /**
+ * A deep description: https://fingerprint.com/blog/audio-fingerprinting/
+ * Inspired by and based on https://github.com/cozylife/audio-fingerprint
+ *
  * A version of the entropy source with stabilization to make it suitable for static fingerprinting.
- * Audio signal is noised in private mode of Safari 17.
+ * Audio signal is noised in private mode of Safari 17, so audio fingerprinting is skipped in Safari 17.
  */
-export default async function getAudioFingerprint(): Promise<() => number> {
-  const finish = await getUnstableAudioFingerprint()
-  return () => {
-    const rawFingerprint = finish()
-    return stabilize(rawFingerprint, stabilizationPrecision)
+export default function getAudioFingerprint(): number | (() => Promise<number>) {
+  if (doesBrowserPerformAntifingerprinting()) {
+    return SpecialFingerprint.KnownForAntifingerprinting
   }
+
+  return getUnstableAudioFingerprint()
 }
 
 /**
@@ -33,30 +38,7 @@ export default async function getAudioFingerprint(): Promise<() => number> {
  * Warning for package users:
  * This function is out of Semantic Versioning, i.e. can change unexpectedly. Usage is at your own risk.
  */
-export async function getUnstableAudioFingerprint(): Promise<() => number> {
-  let fingerprintResult: [true, number] | [false, unknown] | undefined
-
-  // The timeout is not started until the browser tab becomes visible because some browsers may not want to render
-  // an audio context in background.
-  const timeoutPromise = whenDocumentVisible().then(() => wait(500))
-  const fingerprintPromise = getBaseAudioFingerprint().then(
-    (result) => (fingerprintResult = [true, result]),
-    (error) => (fingerprintResult = [false, error]),
-  )
-  await Promise.race([timeoutPromise, fingerprintPromise])
-
-  return () => {
-    if (!fingerprintResult) {
-      return SpecialFingerprint.Timeout
-    }
-    if (!fingerprintResult[0]) {
-      throw fingerprintResult[1]
-    }
-    return fingerprintResult[1]
-  }
-}
-
-async function getBaseAudioFingerprint(): Promise<number> {
+export function getUnstableAudioFingerprint(): number | (() => Promise<number>) {
   const w = window
   const AudioContext = w.OfflineAudioContext || w.webkitOfflineAudioContext
   if (!AudioContext) {
@@ -71,85 +53,85 @@ async function getBaseAudioFingerprint(): Promise<number> {
     return SpecialFingerprint.KnownForSuspending
   }
 
-  const baseSignal = await getBaseSignal(AudioContext)
-  if (!baseSignal) {
-    return SpecialFingerprint.Timeout
-  }
-
-  // This context copies the last sample of the base signal many times.
-  // The array of copies helps to cancel the noise.
-  const context = new AudioContext(1, baseSignal.length - 1 + cloneCount, sampleRate)
-  const sourceNode = context.createBufferSource()
-  sourceNode.buffer = baseSignal
-  sourceNode.loop = true
-  sourceNode.loopStart = (baseSignal.length - 1) / sampleRate
-  sourceNode.loopEnd = baseSignal.length / sampleRate
-  sourceNode.connect(context.destination)
-  sourceNode.start()
-
-  const clonedSignal = await renderAudio(context)
-  if (!clonedSignal) {
-    return SpecialFingerprint.Timeout
-  }
-  const fingerprint = extractFingerprint(baseSignal, clonedSignal.getChannelData(0).subarray(baseSignal.length - 1))
-  return Math.abs(fingerprint) // The fingerprint is made positive to avoid confusion with the special fingerprints
-}
-
-/**
- * Checks if the current browser is known for always suspending audio context.
- *
- * Warning for package users:
- * This function is out of Semantic Versioning, i.e. can change unexpectedly. Usage is at your own risk.
- */
-export function doesBrowserSuspendAudioContext() {
-  // Mobile Safari 11 and older
-  return isWebKit() && !isDesktopWebKit() && !isWebKit606OrNewer()
-}
-
-/**
- * Produces an arbitrary audio signal
- */
-async function getBaseSignal(AudioContext: typeof OfflineAudioContext) {
-  const targetSampleIndex = 3395
-  const context = new AudioContext(1, targetSampleIndex + 1, sampleRate)
+  const hashFromIndex = 4500
+  const hashToIndex = 5000
+  const context = new AudioContext(1, hashToIndex, 44100)
 
   const oscillator = context.createOscillator()
-  oscillator.type = 'square'
-  oscillator.frequency.value = 1000
+  oscillator.type = 'triangle'
+  oscillator.frequency.value = 10000
 
   const compressor = context.createDynamicsCompressor()
-  compressor.threshold.value = -70
+  compressor.threshold.value = -50
   compressor.knee.value = 40
   compressor.ratio.value = 12
   compressor.attack.value = 0
   compressor.release.value = 0.25
 
-  const filter = context.createBiquadFilter()
-  filter.type = 'allpass'
-  filter.frequency.value = 5.239622852977861
-  filter.Q.value = 0.1
-
   oscillator.connect(compressor)
-  compressor.connect(filter)
-  filter.connect(context.destination)
+  compressor.connect(context.destination)
   oscillator.start(0)
 
-  return await renderAudio(context)
+  const [renderPromise, finishRendering] = startRenderingAudio(context)
+  const fingerprintPromise = renderPromise.then(
+    (buffer) => getHash(buffer.getChannelData(0).subarray(hashFromIndex)),
+    (error) => {
+      if (error.name === InnerErrorName.Timeout || error.name === InnerErrorName.Suspended) {
+        return SpecialFingerprint.Timeout
+      }
+      throw error
+    },
+  )
+
+  // Suppresses the console error message in case when the fingerprint fails before requested
+  suppressUnhandledRejectionWarning(fingerprintPromise)
+
+  return () => {
+    finishRendering()
+    return fingerprintPromise
+  }
 }
 
 /**
- * Renders the given audio context with configured nodes.
- * Returns `null` when the rendering runs out of attempts.
- *
- * Warning for package users:
- * This function is out of Semantic Versioning, i.e. can change unexpectedly. Usage is at your own risk.
+ * Checks if the current browser is known for always suspending audio context
  */
-export function renderAudio(context: OfflineAudioContext) {
-  return new Promise<AudioBuffer | null>((resolve, reject) => {
-    const retryDelay = 200
-    let attemptsLeft = 25
+function doesBrowserSuspendAudioContext() {
+  // Mobile Safari 11 and older
+  return isWebKit() && !isDesktopWebKit() && !isWebKit606OrNewer()
+}
+
+/**
+ * Checks if the current browser is known for applying anti-fingerprinting measures in all or some critical modes
+ */
+function doesBrowserPerformAntifingerprinting() {
+  // Safari 17
+  return isWebKit() && isWebKit616OrNewer() && isSafariWebKit()
+}
+
+/**
+ * Starts rendering the audio context.
+ * When the returned function is called, the render process starts finishing.
+ */
+function startRenderingAudio(context: OfflineAudioContext) {
+  const renderTryMaxCount = 3
+  const renderRetryDelay = 500
+  const runningMaxAwaitTime = 500
+  const runningSufficientTime = 5000
+  let finalize = () => undefined as void
+
+  const resultPromise = new Promise<AudioBuffer>((resolve, reject) => {
+    let isFinalized = false
+    let renderTryCount = 0
+    let startedRunningAt = 0
 
     context.oncomplete = (event) => resolve(event.renderedBuffer)
+
+    const startRunningTimeout = () => {
+      setTimeout(
+        () => reject(makeInnerError(InnerErrorName.Timeout)),
+        Math.min(runningMaxAwaitTime, startedRunningAt + runningSufficientTime - Date.now()),
+      )
+    }
 
     const tryRender = () => {
       try {
@@ -157,26 +139,35 @@ export function renderAudio(context: OfflineAudioContext) {
 
         // `context.startRendering` has two APIs: Promise and callback, we check that it's really a promise just in case
         if (isPromise(renderingPromise)) {
-          // Suppresses all unhandled rejections in case of scheduled redundant retries after successful rendering
+          // Suppresses all unhadled rejections in case of scheduled redundant retries after successful rendering
           suppressUnhandledRejectionWarning(renderingPromise)
         }
 
-        // Sometimes the audio context doesn't start after calling `startRendering` (in addition to the cases where
-        // audio context doesn't start at all). A known case is starting an audio context when the browser tab is in
-        // background on iPhone. Retries usually help in this case.
-        if (context.state === 'suspended') {
-          // The audio context can reject starting until the tab is in foreground. Long fingerprint duration
-          // in background isn't a problem, therefore the retry attempts don't count in background. It can lead to
-          // a situation when a fingerprint takes very long time and finishes successfully. FYI, the audio context
-          // can be suspended when `document.hidden === false` and start running after a retry.
-          if (!document.hidden) {
-            attemptsLeft--
-          }
-          if (attemptsLeft > 0) {
-            setTimeout(tryRender, retryDelay)
-          } else {
-            resolve(null)
-          }
+        switch (context.state) {
+          case 'running':
+            startedRunningAt = Date.now()
+            if (isFinalized) {
+              startRunningTimeout()
+            }
+            break
+
+          // Sometimes the audio context doesn't start after calling `startRendering` (in addition to the cases where
+          // audio context doesn't start at all). A known case is starting an audio context when the browser tab is in
+          // background on iPhone. Retries usually help in this case.
+          case 'suspended':
+            // The audio context can reject starting until the tab is in foreground. Long fingerprint duration
+            // in background isn't a problem, therefore the retry attempts don't count in background. It can lead to
+            // a situation when a fingerprint takes very long time and finishes successfully. FYI, the audio context
+            // can be suspended when `document.hidden === false` and start running after a retry.
+            if (!document.hidden) {
+              renderTryCount++
+            }
+            if (isFinalized && renderTryCount >= renderTryMaxCount) {
+              reject(makeInnerError(InnerErrorName.Suspended))
+            } else {
+              setTimeout(tryRender, renderRetryDelay)
+            }
+            break
         }
       } catch (error) {
         reject(error)
@@ -184,76 +175,30 @@ export function renderAudio(context: OfflineAudioContext) {
     }
 
     tryRender()
+
+    finalize = () => {
+      if (!isFinalized) {
+        isFinalized = true
+        if (startedRunningAt > 0) {
+          startRunningTimeout()
+        }
+      }
+    }
   })
+
+  return [resultPromise, finalize] as const
 }
 
-function extractFingerprint(baseSignal: AudioBuffer, clonedSample: Float32Array): number {
-  let fingerprint = undefined
-  let needsDenoising = false
-
-  for (let i = 0; i < clonedSample.length; i += Math.floor(clonedSample.length / 10)) {
-    if (clonedSample[i] === 0) {
-      // In some cases the signal is 0 on a short range for some reason. Ignoring such samples.
-    } else if (fingerprint === undefined) {
-      fingerprint = clonedSample[i]
-    } else if (fingerprint !== clonedSample[i]) {
-      needsDenoising = true
-      break
-    }
+function getHash(signal: ArrayLike<number>): number {
+  let hash = 0
+  for (let i = 0; i < signal.length; ++i) {
+    hash += Math.abs(signal[i])
   }
-
-  // The looped buffer source works incorrectly in old Safari versions (>14 desktop, >15 mobile).
-  // The looped signal contains only 0s. To fix it, the loop start should be `baseSignal.length - 1.00000000001` and
-  // the loop end should be `baseSignal.length + 0.00000000001` (there can be 10 or 11 0s after the point). But this
-  // solution breaks the looped signal in other browsers. Instead of checking the browser version, we check that the
-  // looped signals comprises only 0s, and if it does, we return the last value of the base signal, because old Safari
-  // versions don't add noise that we want to cancel.
-  if (fingerprint === undefined) {
-    fingerprint = baseSignal.getChannelData(0)[baseSignal.length - 1]
-  } else if (needsDenoising) {
-    fingerprint = getMiddle(clonedSample)
-  }
-
-  return fingerprint
+  return hash
 }
 
-/**
- * Calculates the middle between the minimum and the maximum array item
- */
-export function getMiddle(signal: ArrayLike<number>): number {
-  let min = Infinity
-  let max = -Infinity
-
-  for (let i = 0; i < signal.length; i++) {
-    const value = signal[i]
-    // In very rare cases the signal is 0 on a short range for some reason. Ignoring such samples.
-    if (value === 0) {
-      continue
-    }
-    if (value < min) {
-      min = value
-    }
-    if (value > max) {
-      max = value
-    }
-  }
-
-  return (min + max) / 2
-}
-
-/**
- * Truncates some digits of the number to make it stable.
- * `precision` is the number of significant digits to keep. The number may be not integer:
- *  - If it ends with `.2`, the last digit is rounded to the nearest multiple of 5;
- *  - If it ends with `.5`, the last digit is rounded to the nearest even number;
- */
-export function stabilize(value: number, precision: number): number {
-  if (value === 0) {
-    return value
-  }
-
-  const power = Math.floor(Math.log10(Math.abs(value)))
-  const precisionPower = power - Math.floor(precision) + 1
-  const precisionBase = 10 ** -precisionPower * ((precision * 10) % 10 || 1)
-  return Math.round(value * precisionBase) / precisionBase
+function makeInnerError(name: InnerErrorName) {
+  const error = new Error(name)
+  error.name = name
+  return error
 }

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -118,22 +118,3 @@ export function addStyleString(style: CSSStyleDeclaration, source: string): void
     }
   }
 }
-
-/**
- * The returned promise resolves when the tab becomes visible (in foreground).
- * If the tab is already visible, resolves immediately.
- */
-export function whenDocumentVisible(): Promise<void> {
-  return new Promise((resolve) => {
-    const d = document
-    const eventName = 'visibilitychange'
-    const handleVisibilityChange = () => {
-      if (!d.hidden) {
-        d.removeEventListener(eventName, handleVisibilityChange)
-        resolve()
-      }
-    }
-    d.addEventListener(eventName, handleVisibilityChange)
-    handleVisibilityChange()
-  })
-}


### PR DESCRIPTION
Because Safari developers [defeated](https://github.com/WebKit/WebKit/commit/775bac300c8b006803ba1d5c2f7bf28a0f77bc69) our audio denoising recently.

This PR reverts the related changes from 0b398a9c2ce056c472be1e9a35d5884fda52a60f. It has no other changes.