### PR TITLE
Remove the `Feature policy 'Payment' check failed...` console error in cross-origin iframes in Safari

### DIFF
--- a/src/sources/apple_pay.test.ts
+++ b/src/sources/apple_pay.test.ts
@@ -49,39 +49,6 @@ describe('Sources', () => {
         ),
       ).toBe(ApplePayState.NotAvailableInInsecureContext)
 
-      // Safari 10
-      expect(
-        getStateFromError(
-          makeError(
-            'InvalidAccessError',
-            'Trying to call an ApplePaySession API ' +
-              'from a document with an different security origin than its top-level frame.',
-          ),
-        ),
-      ).toEqual(ApplePayState.NotAvailableInFrame)
-
-      // Safari 11-14
-      expect(
-        getStateFromError(
-          makeError(
-            'InvalidAccessError',
-            'Trying to start an Apple Pay session ' +
-              'from a document with an different security origin than its top-level frame.',
-          ),
-        ),
-      ).toEqual(ApplePayState.NotAvailableInFrame)
-
-      // Safari 15-16
-      expect(
-        getStateFromError(
-          makeError(
-            'SecurityError',
-            'Third-party iframes are not allowed to request payments ' +
-              'unless explicitly allowed via Feature-Policy (payment)',
-          ),
-        ),
-      ).toEqual(ApplePayState.NotAvailableInFrame)
-
       expect(() => getStateFromError(makeError('TypeError', 'Other error'))).toThrowMatching(
         (thrown) => thrown.name === 'TypeError' && thrown.message === 'Other error',
       )

--- a/src/sources/apple_pay.ts
+++ b/src/sources/apple_pay.ts
@@ -1,3 +1,5 @@
+import { isAnyParentCrossOrigin } from '../utils/dom'
+
 export const enum ApplePayState {
   /* Apple Pay is disabled on the user device. Seems like it's never returned on iOS (based on few observations). */
   Disabled = 0,
@@ -9,7 +11,7 @@ export const enum ApplePayState {
   NotAvailableInInsecureContext = -2,
   /**
    * Using Apple Pay isn't allowed because the code runs in a frame,
-   * and the frame origin doesn't match the top level page origin.
+   * and the frame origin doesn't match all parent page origins.
    */
   NotAvailableInFrame = -3,
 }
@@ -25,6 +27,10 @@ export default function getApplePayState(): 0 | 1 | -1 | -2 | -3 {
     return ApplePayState.NoAPI
   }
 
+  if (willPrintConsoleError()) {
+    return ApplePayState.NotAvailableInFrame
+  }
+
   try {
     return ApplePaySession.canMakePayments() ? ApplePayState.Enabled : ApplePayState.Disabled
   } catch (error) {
@@ -32,24 +38,24 @@ export default function getApplePayState(): 0 | 1 | -1 | -2 | -3 {
   }
 }
 
-export function getStateFromError(
-  error: unknown,
-): Exclude<ApplePayState, ApplePayState.Disabled | ApplePayState.Enabled | ApplePayState.NoAPI> {
-  if (error instanceof Error) {
-    // See full expected error messages in the test
-    if (error.name === 'InvalidAccessError') {
-      if (/\bfrom\b.*\binsecure\b/i.test(error.message)) {
-        return ApplePayState.NotAvailableInInsecureContext
-      }
-      if (/\bdifferent\b.*\borigin\b.*top.level\b.*\bframe\b/i.test(error.message)) {
-        return ApplePayState.NotAvailableInFrame
-      }
-    }
-    if (error.name === 'SecurityError') {
-      if (/\bthird.party iframes?.*\bnot.allowed\b/i.test(error.message)) {
-        return ApplePayState.NotAvailableInFrame
-      }
-    }
+/**
+ * Starting from Safari 15 calling `ApplePaySession.canMakePayments()` produces this error message when FingerprintJS
+ * runs in an iframe with a cross-origin parent page, and the iframe on that page has no allow="payment *" attribute:
+ *   Feature policy 'Payment' check failed for element with origin 'https://example.com' and allow attribute ''.
+ * This function checks whether the error message is expected.
+ *
+ * We check for cross-origin parents, which is prone to false-positive results. Instead, we should check for allowed
+ * feature/permission, but we can't because none of these API works in Safari yet:
+ *   navigator.permissions.query({ name: ‘payment' })
+ *   navigator.permissions.query({ name: ‘payment-handler' })
+ *   document.featurePolicy
+ */
+const willPrintConsoleError = isAnyParentCrossOrigin
+
+export function getStateFromError(error: unknown): ApplePayState.NotAvailableInInsecureContext {
+  // See full expected error messages in the test
+  if (error instanceof Error && error.name === 'InvalidAccessError' && /\bfrom\b.*\binsecure\b/i.test(error.message)) {
+    return ApplePayState.NotAvailableInInsecureContext
   }
 
   throw error

--- a/src/utils/dom.test.ts
+++ b/src/utils/dom.test.ts
@@ -1,4 +1,4 @@
-import { addStyleString } from './dom'
+import { addStyleString, isAnyParentCrossOrigin } from './dom'
 
 describe('DOM utilities', () => {
   it('adds style string', () => {
@@ -10,5 +10,10 @@ describe('DOM utilities', () => {
       'text-align: center',
       'width: 450px',
     ])
+  })
+
+  it('checks for cross-origin iframe', () => {
+    // Assuming the tests run only with Karma, which doesn't run tests inside an iframe
+    expect(isAnyParentCrossOrigin()).toBeFalse()
   })
 })

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -118,3 +118,31 @@ export function addStyleString(style: CSSStyleDeclaration, source: string): void
     }
   }
 }
+
+/**
+ * Returns true if the code runs in an iframe, and any parent page's origin doesn't match the current origin
+ */
+export function isAnyParentCrossOrigin(): boolean {
+  let currentWindow: Window = window
+
+  for (;;) {
+    const parentWindow = currentWindow.parent
+    if (!parentWindow || parentWindow === currentWindow) {
+      return false // The top page is reached
+    }
+
+    try {
+      if (parentWindow.location.origin !== currentWindow.location.origin) {
+        return true
+      }
+    } catch (error) {
+      // The error is thrown when `origin` is accessed on `parentWindow.location` when the parent is cross-origin
+      if (error instanceof Error && error.name === 'SecurityError') {
+        return true
+      }
+      throw error
+    }
+
+    currentWindow = parentWindow
+  }
+}


### PR DESCRIPTION
By disabling the `applePay` entropy source in cross-origin iframes.