### PR TITLE
Add Safari 18 to the list of tested browsers

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "tslib": "^2.4.1"
   },
   "devDependencies": {
-    "@fpjs-incubator/broyster": "^0.2.0",
+    "@fpjs-incubator/broyster": "^0.2.1",
     "@rollup/plugin-json": "^5.0.1",
     "@rollup/plugin-node-resolve": "^15.0.1",
     "@rollup/plugin-terser": "^0.2.1",

--- a/src/utils/browser.ts
+++ b/src/utils/browser.ts
@@ -76,7 +76,7 @@ export function isChromium(): boolean {
  * This function is out of Semantic Versioning, i.e. can change unexpectedly. Usage is at your own risk.
  */
 export function isWebKit(): boolean {
-  // Based on research in September 2020
+  // Based on research in August 2024
   const w = window
   const n = navigator
 
@@ -86,7 +86,7 @@ export function isWebKit(): boolean {
       'CSSPrimitiveValue' in w,
       'Counter' in w,
       n.vendor.indexOf('Apple') === 0,
-      'getStorageUpdates' in n,
+      'RGBColor' in w,
       'WebKitMediaKeys' in w,
     ]) >= 4
   )

--- a/yarn.lock
+++ b/yarn.lock
@@ -233,10 +233,10 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
-"@fpjs-incubator/broyster@^0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@fpjs-incubator/broyster/-/broyster-0.2.0.tgz#b2f5a190732279dee12039f6746e56d7b8236a72"
-  integrity sha512-26peB8A9XNZ28n61GW4Veq77eJtwQO79iXgamLXGzzbscf8XzV8tqBsO0SeU7I0nN6JN3QXBY6jsRVEZ0Y7crA==
+"@fpjs-incubator/broyster@^0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@fpjs-incubator/broyster/-/broyster-0.2.1.tgz#05fb1052da23e53aebedd9f62b4ecab61e27ff4c"
+  integrity sha512-GmE8/6wrACogDszd8Z5y52z/rGRPvhKvYTmuVFmmIe7udSELpRC+F1qliBD4Oa/lJUY4GKqiDKOSjc91hxLntA==
   dependencies:
     "@types/karma" "^6.3.3"
     async-lock "^1.4.0"


### PR DESCRIPTION
I've checked that all the entropy sources are stable in Safari 18 (including Private Mode) and show no unexpected behavior.