### PR TITLE
Check the browser detectors in modern browsers

### DIFF
--- a/src/utils/browser.ts
+++ b/src/utils/browser.ts
@@ -125,7 +125,7 @@ export function isDesktopWebKit(): boolean {
  */
 export function isSafariWebKit(): boolean {
   // Checked in Safari, Chrome, Firefox, Yandex, UC Browser, Opera, Edge and DuckDuckGo.
-  // iOS Safari and Chrome were checked on iOS 11-18. DuckDuckGo was checked on iOS 17 and macOS 14.
+  // iOS Safari and Chrome were checked on iOS 11-18. DuckDuckGo was checked on iOS 17-18 and macOS 14-15.
   // Desktop Safari versions 12-18 were checked.
   // The other browsers were checked on iOS 17 and 18; there was no chance to check them on the other OS versions.
 
@@ -166,7 +166,7 @@ export function isGecko(): boolean {
  * It doesn't check that the browser is based on Chromium, there is a separate function for this.
  */
 export function isChromium86OrNewer(): boolean {
-  // Checked in Chrome 85 vs Chrome 86 both on desktop and Android
+  // Checked in Chrome 85 vs Chrome 86 both on desktop and Android. Checked in macOS Chrome 128, Android Chrome 127.
   const w = window
 
   return (
@@ -186,7 +186,7 @@ export function isChromium86OrNewer(): boolean {
  * @see https://en.wikipedia.org/wiki/Safari_version_history#Release_history Safari-WebKit versions map
  */
 export function isWebKit606OrNewer(): boolean {
-  // Checked in Safari 9–17
+  // Checked in Safari 9–18
   const w = window
 
   return (
@@ -228,10 +228,10 @@ export function isWebKit616OrNewer(): boolean {
  */
 export function isIPad(): boolean {
   // Checked on:
-  // Safari on iPadOS (both mobile and desktop modes): 8, 11-17
-  // Chrome on iPadOS (both mobile and desktop modes): 11-17
-  // Safari on iOS (both mobile and desktop modes): 9-17
-  // Chrome on iOS (both mobile and desktop modes): 9-17
+  // Safari on iPadOS (both mobile and desktop modes): 8, 11-18
+  // Chrome on iPadOS (both mobile and desktop modes): 11-18
+  // Safari on iOS (both mobile and desktop modes): 9-18
+  // Chrome on iOS (both mobile and desktop modes): 9-18
 
   // Before iOS 13. Safari tampers the value in "request desktop site" mode since iOS 13.
   if (navigator.platform === 'iPad') {
@@ -243,9 +243,12 @@ export function isIPad(): boolean {
 
   return (
     countTruthy([
-      'MediaSource' in window, // Since iOS 13
-      !!Element.prototype.webkitRequestFullscreen, // Since iOS 12
+      // Since iOS 13. Doesn't work in Chrome on iPadOS <15, but works in desktop mode.
+      'MediaSource' in window,
+      // Since iOS 12. Doesn't work in Chrome on iPadOS.
+      !!Element.prototype.webkitRequestFullscreen,
       // iPhone 4S that runs iOS 9 matches this, but it is not supported
+      // Doesn't work in incognito mode of Safari ≥17 with split screen because of tracking prevention
       screenRatio > 0.65 && screenRatio < 1.53,
     ]) >= 2
   )
@@ -289,11 +292,11 @@ export function isAndroid(): boolean {
         // Removal proposal https://bugs.chromium.org/p/chromium/issues/detail?id=699892
         // Note: this expression returns true on ChromeOS, so additional detectors are required to avoid false-positives
         n[c] && 'ontypechange' in n[c],
-        !('sinkId' in new window.Audio()),
+        !('sinkId' in new Audio()),
       ]) >= 2
     )
   } else if (isItGecko) {
-    return countTruthy(['onorientationchange' in w, 'orientation' in w, /android/i.test(navigator.appVersion)]) >= 2
+    return countTruthy(['onorientationchange' in w, 'orientation' in w, /android/i.test(n.appVersion)]) >= 2
   } else {
     // Only 2 browser engines are presented on Android.
     // Actually, there is also Android 4.1 browser, but it's not worth detecting it at the moment.


### PR DESCRIPTION
Checked in:

- macOS Safari 18
- macOS Chrome 18
- macOS Firefox 130
- macOS DuckDuckGo 1.103
- iOS 18 Safari
- iOS 18 Chrome
- iOS 18 DuckDuckGo
- iPadOS 18 Safari (regular mode, incognito and desktop mode)
- iPadOS 18 Chrome (regular mode, incognito and desktop mode)
- ChromeOS 128
- Android Chrome 127 (regular and desktop mode)
- Android Firefox 127 (regular and desktop mode)