### PR TITLE
fix: A vendorFlavors test fails in headless Chrome

### DIFF
--- a/src/sources/vendor_flavors.test.ts
+++ b/src/sources/vendor_flavors.test.ts
@@ -1,4 +1,4 @@
-import { isChromium, isGecko, isHeadlessChrome, isMobile, isSafari, isWebKit } from '../../tests/utils'
+import { isChromium, isGecko, isMobile, isSafari, isWebKit } from '../../tests/utils'
 import getVendorFlavors from './vendor_flavors'
 
 describe('Sources', () => {
@@ -17,7 +17,7 @@ describe('Sources', () => {
       const result = getVendorFlavors()
 
       if (isChromium()) {
-        expect(result).toEqual(isHeadlessChrome() ? [] : ['chrome'])
+        expect(result).toEqual(['chrome'])
         return
       }
 

--- a/tests/utils/index.ts
+++ b/tests/utils/index.ts
@@ -26,10 +26,6 @@ export function isChromium(): boolean {
   return new UAParser().getEngine().name === 'Blink'
 }
 
-export function isHeadlessChrome(): boolean {
-  return navigator.userAgent.includes('HeadlessChrome')
-}
-
 export function isGecko(): boolean {
   return new UAParser().getEngine().name === 'Gecko'
 }


### PR DESCRIPTION
Headless Chrome behavior changed in version 128.