### PR TITLE
Disable the audio fingerprint component in Samsung Internet 26+

### DIFF
--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -5,6 +5,7 @@ interface Window {
   openDatabase?(...args: unknown[]): void
   ApplePaySession?: ApplePaySessionConstructor
   __fpjs_d_m?: unknown
+  URLPattern?: new (...args: unknown[]) => unknown
 }
 
 interface Navigator {

--- a/src/sources/audio.ts
+++ b/src/sources/audio.ts
@@ -1,4 +1,4 @@
-import { isDesktopWebKit, isSafariWebKit, isWebKit, isWebKit606OrNewer, isWebKit616OrNewer } from '../utils/browser'
+import * as browser from '../utils/browser'
 import { isPromise, suppressUnhandledRejectionWarning } from '../utils/async'
 
 export const enum SpecialFingerprint {
@@ -97,15 +97,19 @@ export function getUnstableAudioFingerprint(): number | (() => Promise<number>) 
  */
 function doesBrowserSuspendAudioContext() {
   // Mobile Safari 11 and older
-  return isWebKit() && !isDesktopWebKit() && !isWebKit606OrNewer()
+  return browser.isWebKit() && !browser.isDesktopWebKit() && !browser.isWebKit606OrNewer()
 }
 
 /**
  * Checks if the current browser is known for applying anti-fingerprinting measures in all or some critical modes
  */
 function doesBrowserPerformAntifingerprinting() {
-  // Safari 17
-  return isWebKit() && isWebKit616OrNewer() && isSafariWebKit()
+  return (
+    // Safari ≥17
+    (browser.isWebKit() && browser.isWebKit616OrNewer() && browser.isSafariWebKit()) ||
+    // Samsung Internet ≥26
+    (browser.isChromium() && browser.isSamsungInternet() && browser.isChromium122OrNewer())
+  )
 }
 
 /**

--- a/src/utils/browser.test.ts
+++ b/src/utils/browser.test.ts
@@ -37,6 +37,13 @@ describe('Browser utilities', () => {
       expect(browser.isChromium86OrNewer()).toBe((utils.getBrowserEngineMajorVersion() ?? 0) >= 86)
     })
 
+    it('detects Chromium 122+', () => {
+      if (!utils.isChromium()) {
+        return
+      }
+      expect(browser.isChromium122OrNewer()).toBe((utils.getBrowserEngineMajorVersion() ?? 0) >= 122)
+    })
+
     // WebKit has stopped telling its real version in the user-agent string since version 605.1.15,
     // therefore the browser version has to be checked instead of the engine version.
     it('detects Safari 12+', () => {
@@ -67,6 +74,13 @@ describe('Browser utilities', () => {
         return
       }
       expect(browser.isSafariWebKit()).toBe(utils.isSafari())
+    })
+
+    it('detects Samsung Internet', () => {
+      if (!utils.isChromium()) {
+        return
+      }
+      expect(browser.isSamsungInternet()).toBe(utils.isSamsungInternet())
     })
   })
 

--- a/src/utils/browser.ts
+++ b/src/utils/browser.ts
@@ -180,6 +180,25 @@ export function isChromium86OrNewer(): boolean {
 }
 
 /**
+ * Checks whether the browser is based on Chromium version ≥122 without using user-agent.
+ * It doesn't check that the browser is based on Chromium, there is a separate function for this.
+ */
+export function isChromium122OrNewer(): boolean {
+  // Checked in Chrome 121 vs Chrome 122 and 129 both on desktop and Android
+  const w = window
+  const { URLPattern } = w
+
+  return (
+    countTruthy([
+      'union' in Set.prototype,
+      'Iterator' in w,
+      URLPattern && 'hasRegExpGroups' in URLPattern.prototype,
+      'RGB8' in WebGLRenderingContext.prototype,
+    ]) >= 3
+  )
+}
+
+/**
  * Checks whether the browser is based on WebKit version ≥606 (Safari ≥12) without using user-agent.
  * It doesn't check that the browser is based on WebKit, there is a separate function for this.
  *
@@ -302,4 +321,26 @@ export function isAndroid(): boolean {
     // Actually, there is also Android 4.1 browser, but it's not worth detecting it at the moment.
     return false
   }
+}
+
+/**
+ * Checks whether the browser is Samsung Internet without using user-agent.
+ * It doesn't check that the browser is based on Chromium, please use `isChromium` before using this function.
+ */
+export function isSamsungInternet(): boolean {
+  // Checked in Samsung Internet 21, 25 and 27
+  const n = navigator
+  const w = window
+  const audioPrototype = Audio.prototype
+  const { visualViewport } = w
+
+  return (
+    countTruthy([
+      'srLatency' in audioPrototype,
+      'srChannelCount' in audioPrototype,
+      'devicePosture' in n, // Not available in HTTP
+      visualViewport && 'segments' in visualViewport,
+      'getTextInformation' in Image.prototype, // Not available in Samsung Internet 21
+    ]) >= 3
+  )
 }

--- a/tests/utils/index.ts
+++ b/tests/utils/index.ts
@@ -62,6 +62,11 @@ export function isSafari(): boolean {
   return browserName === 'Safari' || browserName === 'Mobile Safari'
 }
 
+export function isSamsungInternet(): boolean {
+  const browserName = new UAParser().getBrowser().name
+  return browserName === 'Samsung Internet'
+}
+
 /**
  * Probably you should use `getBrowserEngineMajorVersion` instead
  */


### PR DESCRIPTION
Fixes #1030 

Disabling the audio entropy source makes FingerprintJS produce stable fingerprints in Samsung Internet.

We don't try to circumvent the Samsung Internet's antifingerprinting, because it will be fixed by Samsung soon, so the outcome will be the same.