### PR TITLE
NPM publishing workflow

### DIFF
--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -4,14 +4,14 @@
 # The environment should be protected to allow running only on the master branch.
 
 name: Publish to NPM
-on: [workflow_dispatch, push] # todo: Remove the temporary "push" trigger
+on: workflow_dispatch
 
 jobs:
   publish:
     name: Build and publish
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    # environment: npm # todo: Uncomment
+    environment: npm
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -35,7 +35,6 @@ jobs:
           echo -e "Version: $version\nVersion tag: $tag"
           echo -e "version=$version\ntag=$tag" >> $GITHUB_OUTPUT
       - name: Publish to NPM
-        continue-on-error: true # todo: Remove this temporary option
         # This command will automatically fail because of some common mistakes (this is a wanted behavior):
         # - The current version is already published
         # - The package uses a local directory as a dependency
@@ -46,5 +45,5 @@ jobs:
       - name: Create a Git tag
         uses: rickstaa/action-create-tag@v1
         with:
-          tag: test-v${{ steps.version.outputs.version }} # todo: Remove test-
+          tag: v${{ steps.version.outputs.version }}
           message: " "

--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -29,7 +29,11 @@ jobs:
         run: yarn build
       - name: Get the package version
         id: version
-        run: echo "version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
+        run: |
+          version=$(node -p "require('./package.json').version")
+          tag=$(echo "$version" | grep -oP '(?<=-)[^.]+' || echo "latest")
+          echo -e "Version: $version\nVersion tag: $tag"
+          echo -e "version=$version\ntag=$tag" >> $GITHUB_OUTPUT
       - name: Publish to NPM
         continue-on-error: true # todo: Remove this temporary option
         # This command will automatically fail because of some common mistakes (this is a wanted behavior):
@@ -38,11 +42,9 @@ jobs:
         # - The NPM access token is invalid or expired
         run: |
           echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_ACCESS_TOKEN }}" > ~/.npmrc
-          tag=$(echo "${{ steps.version.outputs.version }}" | grep -oP '(?<=-)[^.]+' || echo "latest")
-          echo "Publishing version ${{ steps.version.outputs.version }} with tag: $tag"
-          yarn publish --access public --tag "$tag"
+          yarn publish --access public --tag "${{ steps.version.outputs.tag }}"
       - name: Create a Git tag
         uses: rickstaa/action-create-tag@v1
         with:
-          tag: test-v${{ steps.version.outputs.version }}
-          message: ""
+          tag: test-v${{ steps.version.outputs.version }} # todo: Remove test-
+          message: " "

--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -1,0 +1,48 @@
+# Reference on this file: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions
+# In order to work properly, this workflow requires the repository to have an environment called "npm". The environment
+# must have a secret called NPM_ACCESS_TOKEN that holds an NPM access token that allows to publish the packages.
+# The environment should be protected to allow running only on the master branch.
+
+name: Publish to NPM
+on: [workflow_dispatch, push] # todo: Remove the temporary "push" trigger
+
+jobs:
+  publish:
+    name: Build and publish
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # environment: npm # todo: Uncomment
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Cache
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: nodemodules-${{ hashFiles('yarn.lock') }}
+          restore-keys: nodemodules-
+      - name: Install Node packages
+        run: yarn install
+      - name: Build
+        run: yarn build
+      - name: Get the package version
+        id: version
+        run: echo "version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
+      - name: Publish to NPM
+        continue-on-error: true # todo: Remove this temporary option
+        # This command will automatically fail because of some common mistakes (this is a wanted behavior):
+        # - The current version is already published
+        # - The package uses a local directory as a dependency
+        # - The NPM access token is invalid or expired
+        run: |
+          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_ACCESS_TOKEN }}" > ~/.npmrc
+          tag=$(echo "${{ steps.version.outputs.version }}" | grep -oP '(?<=-)[^.]+' || echo "latest")
+          echo "Publishing version ${{ steps.version.outputs.version }} with tag: $tag"
+          yarn publish --access public --tag "$tag"
+      - name: Create a Git tag
+        uses: rickstaa/action-create-tag@v1
+        with:
+          tag: test-v${{ steps.version.outputs.version }}
+          message: ""

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -10,5 +10,6 @@ This guide is for repository maintainers.
 3. When the PR checks succeed and the PR is approved, merge it.
 4. Run the [Publish to NPM](https://github.com/fingerprintjs/fingerprintjs-pro/actions/workflows/npm_publish.yml) workflow by using the "Run workflow" button.
     It will publish the current code to NPM and create a corresponding Git tag.
+    The NPM version tag will be derived automatically from the package version, for example `1.2.3` gives `latest` and `1.2.3-alpha.1` gives `alpha`.
 5. Describe the version changes in the [releases section](https://github.com/fingerprintjs/fingerprintjs/releases) under the corresponding tag.
 6. Update the agent in https://stackblitz.com/edit/fpjs-4-npm (find "dependencies" and click the round arrow).

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -2,16 +2,13 @@
 
 This guide is for repository maintainers.
 
-1. Bump the version. Search the current version number in the code to know where to change it.
-2. Build and test the project.
-3. See what will get into the NPM package, make sure it contains the distribution files and no excess files.
-   To see, run `yarn pack`. An archive will appear nearby. Open it with any archive browser.
-4. Run
-    ```bash
-    # Add '--tag beta' (without the quotes) if you release a beta version
-    # Add '--tag dev' if you release a development version (which is expected to get new features)
-    yarn publish --access public
-    ```
-5. Push the changes to the repository, and a version tag like `v1.3.4` to the commit.
-6. Describe the version changes in the [releases section](https://github.com/fingerprintjs/fingerprintjs/releases).
-7. Update the agent in https://stackblitz.com/edit/fpjs-4-npm (find "dependencies" and click the round arrow).
+1. Create a PR that bumps the version in [package.json](../package.json).
+2. [Build the project](../contributing.md#how-to-build) on your local machine and run `yarn pack`.
+    An archive will be created nearby in the repository root directory.
+    Open the archive and make sure it contains the distribution files and no excess files.
+    If there is something wrong, fix it and push to the PR.
+3. When the PR checks succeed and the PR is approved, merge it.
+4. Run the [Publish to NPM](https://github.com/fingerprintjs/fingerprintjs-pro/actions/workflows/npm_publish.yml) workflow by using the "Run workflow" button.
+    It will publish the current code to NPM and create a corresponding Git tag.
+5. Describe the version changes in the [releases section](https://github.com/fingerprintjs/fingerprintjs/releases) under the corresponding tag.
+6. Update the agent in https://stackblitz.com/edit/fpjs-4-npm (find "dependencies" and click the round arrow).

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fingerprintjs/fingerprintjs",
   "description": "Browser fingerprinting library with the highest accuracy and stability",
-  "version": "4.5.1",
+  "version": "4.5.2-alpha.1",
   "keywords": [
     "fraud",
     "fraud detection",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fingerprintjs/fingerprintjs",
   "description": "Browser fingerprinting library with the highest accuracy and stability",
-  "version": "4.5.2-alpha.1",
+  "version": "4.5.1",
   "keywords": [
     "fraud",
     "fraud detection",


### PR DESCRIPTION
The PR adds a GitHub Actions workflow that starts manually, publishes the current version to NPM and creates a corresponding Git tag. The workflow can run only on the `master` branch (until somebody changes the environment settings in the repository settings).

The goal of the workflow is allowing the repository maintainers to publish the loader package to NPM with having no NPM access token. Limiting the workflow to `master` ensures that at least 2 people are needed to publish a new version to NPM.