### PR TITLE
Add a `withIframe` test for handling delayed document.body availability

### DIFF
--- a/src/utils/dom.test.ts
+++ b/src/utils/dom.test.ts
@@ -1,4 +1,5 @@
-import { addStyleString, isAnyParentCrossOrigin } from './dom'
+import { addStyleString, isAnyParentCrossOrigin, withIframe } from './dom'
+import { withMockProperties } from '../../tests/utils'
 
 describe('DOM utilities', () => {
   it('adds style string', () => {
@@ -15,5 +16,25 @@ describe('DOM utilities', () => {
   it('checks for cross-origin iframe', () => {
     // Assuming the tests run only with Karma, which doesn't run tests inside an iframe
     expect(isAnyParentCrossOrigin()).toBeFalse()
+  })
+
+  describe('Document loading - consistency test', () => {
+    let result: Promise<unknown> | null = null
+    beforeEach(() => jasmine.clock().install())
+    afterEach(() => jasmine.clock().uninstall())
+
+    it('should properly handle delayed document loading', async () => {
+      await withMockProperties(document, { body: { get: () => null } }, async () => {
+        result = withIframe(() => ({}))
+        // Ensure the promise remains pending while document.body is not available - for 500 ms
+        jasmine.clock().tick(500)
+        await expectAsync(result).toBePending()
+      })
+      // Advance (fake) time by 50ms to ensure that enough time is simulated for the withIframe function's default
+      // polling interval to detect that document.body is available, allowing the promise in result to resolve.
+      // This is necessary because withIframe performs repeated checks to ensure the DOM is ready before proceeding.
+      jasmine.clock().tick(50)
+      await expectAsync(result).toBeResolved()
+    })
   })
 })

--- a/src/utils/dom.test.ts
+++ b/src/utils/dom.test.ts
@@ -19,12 +19,10 @@ describe('DOM utilities', () => {
   })
 
   describe('withIframe', () => {
-    describe('with initial null document.body', () => {
-      let result: Promise<unknown> | null = null
-      beforeEach(() => jasmine.clock().install())
-      afterEach(() => jasmine.clock().uninstall())
-
-      it("doesn't fail when document loading is delayed", async () => {
+    it("doesn't fail when document loading is delayed", async () => {
+      try {
+        let result: Promise<unknown> | null = null
+        jasmine.clock().install()
         await withMockProperties(document, { body: { get: () => null } }, async () => {
           result = withIframe(() => ({}))
           // Ensure the promise remains pending while document.body is not available - for 500 ms
@@ -36,7 +34,9 @@ describe('DOM utilities', () => {
         // This is necessary because withIframe performs repeated checks to ensure the DOM is ready before proceeding.
         jasmine.clock().tick(50)
         await expectAsync(result).toBeResolved()
-      })
+      } finally {
+        jasmine.clock().uninstall()
+      }
     })
   })
 })


### PR DESCRIPTION
This test ensures that the withIframe function properly handles scenarios where document.body is initially unavailable, simulating delayed document loading. It verifies that the promise remains pending until document.body becomes available and resolves correctly once it is accessible.