### PR TITLE
Add window.Intl.DateTimeFormat().resolvedOptions().locale as a new signal

### DIFF
--- a/src/sources/date_time_locale.test.ts
+++ b/src/sources/date_time_locale.test.ts
@@ -1,14 +1,5 @@
 import getDateTimeLocale from './date_time_locale'
 
-// This interface is not exported from lib.es5.d.ts, so it has been copy/pasted here to allow referencing it during
-// the initialization of the spy and to satisfy the TypeScript definition.
-interface ResolvedDateTimeFormatOptions {
-  locale: string
-  calendar: string
-  numberingSystem: string
-  timeZone: string
-}
-
 describe('Sources', () => {
   describe('dateTimeLocale', () => {
     describe('cases for browsers that have support for DateTimeFormat locale', () => {
@@ -30,6 +21,7 @@ describe('Sources', () => {
       afterEach(() => {
         window.Intl = originalIntl
       })
+
       it('should return an empty string if Intl.DateTimeFormat is not supported', () => {
         window.Intl = undefined as unknown as typeof Intl
 
@@ -39,7 +31,7 @@ describe('Sources', () => {
 
       it('should return an empty string if resolvedOptions().locale is undefined', () => {
         spyOn(window.Intl, 'DateTimeFormat').and.returnValue({
-          resolvedOptions: () => ({ locale: undefined } as unknown as ResolvedDateTimeFormatOptions),
+          resolvedOptions: () => ({ locale: undefined } as unknown as Intl.ResolvedDateTimeFormatOptions),
           format: () => '',
           formatToParts: () => [],
         })

--- a/src/sources/date_time_locale.test.ts
+++ b/src/sources/date_time_locale.test.ts
@@ -11,7 +11,7 @@ interface ResolvedDateTimeFormatOptions {
 
 describe('Sources', () => {
   describe('dateTimeLocale', () => {
-    describe('cases for browsers that support Intl or locale', () => {
+    describe('cases for browsers that have support for DateTimeFormat locale', () => {
       it('returns string representing dateTime locale', () => {
         const result = getDateTimeLocale()
         expect(typeof result).toBe('string')

--- a/src/sources/date_time_locale.test.ts
+++ b/src/sources/date_time_locale.test.ts
@@ -1,0 +1,12 @@
+import getDateTimeLocale from './date_time_locale'
+
+describe('Sources', () => {
+  describe('dateTimeLocale', () => {
+    it('returns string representing dateTime locale', () => {
+      const result = getDateTimeLocale()
+      expect(typeof result).toBe('string')
+      // The combinations returned as results for the current test suite specified browsers are: "en", "en-US", "en-GB".
+      expect(result).toMatch(/^en(-[A-Z]{2})?$/)
+    })
+  })
+})

--- a/src/sources/date_time_locale.test.ts
+++ b/src/sources/date_time_locale.test.ts
@@ -6,9 +6,17 @@ describe('Sources', () => {
       it('returns string representing dateTime locale', () => {
         const result = getDateTimeLocale()
         expect(typeof result).toBe('string')
-        // The combinations returned as results for the current test suite specified browsers are:
-        // "en", "en-US", "en-GB".
-        expect(result).toMatch(/^en(-[A-Z]{2})?$/)
+        // The combinations returned as results for the current test suite specified browsers on the BrowserStack are:
+        // "en", "en-US", "en-GB",
+        // However, we need to keep in mind that this is an open-source codebase, and developers who contribute might
+        // be working in local environments that do not fall into this predefined set. Therefore, it is important
+        // that our logic for detecting local test runs is flexible and inclusive, ensuring it works for all
+        // contributors regardless of their setup.
+        // Examples of locales: "en-US", "zh-Hans-CN", "fr-CA", "es-419", regex formed by following->
+        // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/resolvedOptions#:~:text=locale-,The%20BCP%2047,-language%20tag%20for
+        // https://datatracker.ietf.org/doc/html/rfc4647#section-3.4
+        const localeRegex = /^[a-z]{2,3}(-[A-Za-z]{4})?(-([A-Z]{2}|[0-9]{3}))?(-[A-Za-z0-9]+)*$/
+        expect(result).toMatch(localeRegex)
       })
     })
     describe("edge cases for browsers that don't support Intl or locale", () => {

--- a/src/sources/date_time_locale.test.ts
+++ b/src/sources/date_time_locale.test.ts
@@ -19,6 +19,7 @@ describe('Sources', () => {
         expect(result).toMatch(localeRegex)
       })
     })
+
     describe("edge cases for browsers that don't support Intl or locale", () => {
       let originalIntl: typeof Intl
 

--- a/src/sources/date_time_locale.test.ts
+++ b/src/sources/date_time_locale.test.ts
@@ -1,12 +1,44 @@
 import getDateTimeLocale from './date_time_locale'
 
-describe('Sources', () => {
+fdescribe('Sources', () => {
   describe('dateTimeLocale', () => {
-    it('returns string representing dateTime locale', () => {
-      const result = getDateTimeLocale()
-      expect(typeof result).toBe('string')
-      // The combinations returned as results for the current test suite specified browsers are: "en", "en-US", "en-GB".
-      expect(result).toMatch(/^en(-[A-Z]{2})?$/)
+    describe("cases for browsers that don't support Intl or locale", () => {
+      it('returns string representing dateTime locale', () => {
+        const result = getDateTimeLocale()
+        expect(typeof result).toBe('string')
+        // The combinations returned as results for the current test suite specified browsers are:
+        // "en", "en-US", "en-GB".
+        expect(result).toMatch(/^en(-[A-Z]{2})?$/)
+      })
+    })
+
+    describe("edge cases for browsers that don't support Intl or locale", () => {
+      let originalIntl: typeof Intl
+
+      beforeEach(() => {
+        originalIntl = window.Intl
+      })
+
+      afterEach(() => {
+        window.Intl = originalIntl
+      })
+      it('should return an empty string if Intl.DateTimeFormat is not supported', () => {
+        window.Intl = undefined as any
+
+        const result = getDateTimeLocale()
+        expect(result).toBe('')
+      })
+
+      it('should return an empty string if resolvedOptions().locale is undefined', () => {
+        spyOn(window.Intl, 'DateTimeFormat').and.returnValue({
+          resolvedOptions: () => ({ locale: undefined } as any),
+          format: () => '',
+          formatToParts: () => [],
+        })
+
+        const result = getDateTimeLocale()
+        expect(result).toBe('')
+      })
     })
   })
 })

--- a/src/sources/date_time_locale.test.ts
+++ b/src/sources/date_time_locale.test.ts
@@ -1,20 +1,12 @@
 import getDateTimeLocale from './date_time_locale'
 
+// This interface is not exported from lib.es5.d.ts, so it has been copy/pasted here to allow referencing it during
+// the initialization of the spy and to satisfy the TypeScript definition.
 interface ResolvedDateTimeFormatOptions {
   locale: string
   calendar: string
   numberingSystem: string
   timeZone: string
-  hour12?: boolean
-  weekday?: string
-  era?: string
-  year?: string
-  month?: string
-  day?: string
-  hour?: string
-  minute?: string
-  second?: string
-  timeZoneName?: string
 }
 
 describe('Sources', () => {

--- a/src/sources/date_time_locale.test.ts
+++ b/src/sources/date_time_locale.test.ts
@@ -1,6 +1,23 @@
 import getDateTimeLocale from './date_time_locale'
 
-fdescribe('Sources', () => {
+interface ResolvedDateTimeFormatOptions {
+  locale: string
+  calendar: string
+  numberingSystem: string
+  timeZone: string
+  hour12?: boolean
+  weekday?: string
+  era?: string
+  year?: string
+  month?: string
+  day?: string
+  hour?: string
+  minute?: string
+  second?: string
+  timeZoneName?: string
+}
+
+describe('Sources', () => {
   describe('dateTimeLocale', () => {
     describe("cases for browsers that don't support Intl or locale", () => {
       it('returns string representing dateTime locale', () => {
@@ -23,7 +40,7 @@ fdescribe('Sources', () => {
         window.Intl = originalIntl
       })
       it('should return an empty string if Intl.DateTimeFormat is not supported', () => {
-        window.Intl = undefined as any
+        window.Intl = undefined as unknown as typeof Intl
 
         const result = getDateTimeLocale()
         expect(result).toBe('')
@@ -31,7 +48,7 @@ fdescribe('Sources', () => {
 
       it('should return an empty string if resolvedOptions().locale is undefined', () => {
         spyOn(window.Intl, 'DateTimeFormat').and.returnValue({
-          resolvedOptions: () => ({ locale: undefined } as any),
+          resolvedOptions: () => ({ locale: undefined } as unknown as ResolvedDateTimeFormatOptions),
           format: () => '',
           formatToParts: () => [],
         })

--- a/src/sources/date_time_locale.test.ts
+++ b/src/sources/date_time_locale.test.ts
@@ -20,7 +20,6 @@ describe('Sources', () => {
         expect(result).toMatch(/^en(-[A-Z]{2})?$/)
       })
     })
-
     describe("edge cases for browsers that don't support Intl or locale", () => {
       let originalIntl: typeof Intl
 

--- a/src/sources/date_time_locale.test.ts
+++ b/src/sources/date_time_locale.test.ts
@@ -11,7 +11,7 @@ interface ResolvedDateTimeFormatOptions {
 
 describe('Sources', () => {
   describe('dateTimeLocale', () => {
-    describe("cases for browsers that don't support Intl or locale", () => {
+    describe('cases for browsers that support Intl or locale', () => {
       it('returns string representing dateTime locale', () => {
         const result = getDateTimeLocale()
         expect(typeof result).toBe('string')

--- a/src/sources/date_time_locale.ts
+++ b/src/sources/date_time_locale.ts
@@ -1,0 +1,6 @@
+/**
+ * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/resolvedOptions
+ */
+export default function getDateTimeLocale(): string {
+  return window.Intl.DateTimeFormat().resolvedOptions().locale
+}

--- a/src/sources/date_time_locale.ts
+++ b/src/sources/date_time_locale.ts
@@ -2,5 +2,13 @@
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/resolvedOptions
  */
 export default function getDateTimeLocale(): string {
-  return window.Intl.DateTimeFormat().resolvedOptions().locale
+  const DateTimeFormat = window.Intl?.DateTimeFormat
+  if (DateTimeFormat) {
+    const locale = new DateTimeFormat().resolvedOptions().locale
+    if (locale) {
+      return locale
+    }
+  }
+
+  return ''
 }

--- a/src/sources/date_time_locale.ts
+++ b/src/sources/date_time_locale.ts
@@ -2,13 +2,9 @@
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/resolvedOptions
  */
 export default function getDateTimeLocale(): string {
-  const DateTimeFormat = window.Intl?.DateTimeFormat
-  if (DateTimeFormat) {
-    const locale = new DateTimeFormat().resolvedOptions().locale
-    if (locale) {
-      return locale
-    }
-  }
+  return getLocaleFromResolvedOption()
+}
 
-  return ''
+function getLocaleFromResolvedOption(): string {
+  return window.Intl?.DateTimeFormat().resolvedOptions().locale || ''
 }

--- a/src/sources/date_time_locale.ts
+++ b/src/sources/date_time_locale.ts
@@ -2,9 +2,9 @@
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/resolvedOptions
  */
 export default function getDateTimeLocale(): string {
-  return getLocaleFromResolvedOption()
+  return getLocaleFromResolvedOptions()
 }
 
-function getLocaleFromResolvedOption(): string {
+function getLocaleFromResolvedOptions(): string {
   return window.Intl?.DateTimeFormat().resolvedOptions().locale || ''
 }

--- a/src/sources/date_time_locale.ts
+++ b/src/sources/date_time_locale.ts
@@ -2,9 +2,5 @@
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/resolvedOptions
  */
 export default function getDateTimeLocale(): string {
-  return getLocaleFromResolvedOptions()
-}
-
-function getLocaleFromResolvedOptions(): string {
   return window.Intl?.DateTimeFormat().resolvedOptions().locale || ''
 }

--- a/src/sources/index.ts
+++ b/src/sources/index.ts
@@ -38,6 +38,7 @@ import getApplePayState from './apple_pay'
 import getPrivateClickMeasurement from './private_click_measurement'
 import { getWebGlBasics, getWebGlExtensions } from './webgl'
 import getAudioContextBaseLatency from './audio_base_latency'
+import getDateTimeLocale from './date_time_locale'
 
 /**
  * The list of entropy sources used to make visitor identifiers.
@@ -94,7 +95,7 @@ export const sources = {
   applePay: getApplePayState,
   privateClickMeasurement: getPrivateClickMeasurement,
   audioBaseLatency: getAudioContextBaseLatency,
-
+  dateTimeLocale: getDateTimeLocale,
   // Some sources can affect other sources (e.g. WebGL can affect canvas), so it's important to run these sources
   // after other sources.
   webGlBasics: getWebGlBasics,

--- a/src/sources/index.ts
+++ b/src/sources/index.ts
@@ -96,6 +96,7 @@ export const sources = {
   privateClickMeasurement: getPrivateClickMeasurement,
   audioBaseLatency: getAudioContextBaseLatency,
   dateTimeLocale: getDateTimeLocale,
+
   // Some sources can affect other sources (e.g. WebGL can affect canvas), so it's important to run these sources
   // after other sources.
   webGlBasics: getWebGlBasics,


### PR DESCRIPTION
**Description:**

This PR introduces support for collecting the `locale` value from `window.Intl.DateTimeFormat().resolvedOptions()` as a new signal. Currently, we only collect the `timeZone` signal from this API, but the `locale` value can provide additional valuable insights into user preferences and browser configurations.

### Key Changes:
1. **New Signal Added:**
   - Added logic to capture `window.Intl.DateTimeFormat().resolvedOptions().locale` as a new signal.
   - This signal complements the existing `timeZone` signal and provides more context about the user's environment.

2. **Browser Compatibility:**
   - The `Intl.DateTimeFormat` API is widely supported across modern browsers, making this a low-risk addition.
   - Fallback mechanisms are in place to handle cases where the locale value is not available or `window.Intl` is not supported

### Testing:
- The changes have been tested across multiple browsers and environments to ensure consistent behavior.
- Integration tests have been added to verify that the `locale` signal is correctly captured and handled.