### PR TITLE
Enforce padding between function definitions with ESLint rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -32,11 +32,7 @@
       ],
       "rules": {
         "max-len": ["error", { "code": 120, "ignoreUrls": true }],
-        "@typescript-eslint/no-unused-vars": ["error", { "ignoreRestSiblings": true }],
-        "padding-line-between-statements": [
-          "error",
-          { "blankLine": "always", "prev": "function", "next": "function" }
-        ]
+        "@typescript-eslint/no-unused-vars": ["error", { "ignoreRestSiblings": true }]
       }
     }
   ]

--- a/.eslintrc
+++ b/.eslintrc
@@ -12,7 +12,11 @@
   "parser": "@typescript-eslint/parser",
   "rules": {
     "no-console": "warn",
-    "max-len": ["error", { "code": 120, "ignoreUrls": true }]
+    "max-len": ["error", { "code": 120, "ignoreUrls": true }],
+    "padding-line-between-statements": [
+      "error",
+      { "blankLine": "always", "prev": "function", "next": "function" }
+    ]
   },
   "overrides": [
     {
@@ -28,7 +32,11 @@
       ],
       "rules": {
         "max-len": ["error", { "code": 120, "ignoreUrls": true }],
-        "@typescript-eslint/no-unused-vars": ["error", { "ignoreRestSiblings": true }]
+        "@typescript-eslint/no-unused-vars": ["error", { "ignoreRestSiblings": true }],
+        "padding-line-between-statements": [
+          "error",
+          { "blankLine": "always", "prev": "function", "next": "function" }
+        ]
       }
     }
   ]

--- a/src/sources/audio.test.ts
+++ b/src/sources/audio.test.ts
@@ -44,6 +44,7 @@ function doesBrowserPerformAntifingerprinting() {
   const isSamsungInternet26orNewer = isSamsungInternet() && (getBrowserMajorVersion() ?? 0) >= 26
   return isSafari17orNewer || isSamsungInternet26orNewer
 }
+
 function doesBrowserSuspendAudioContext() {
   // WebKit has stopped telling its real version in the user-agent string since version 605.1.15,
   // therefore the browser version has to be checked instead of the engine version.

--- a/src/utils/data.test.ts
+++ b/src/utils/data.test.ts
@@ -92,6 +92,7 @@ describe('Data utilities', () => {
       yield { val: 8 }
       yield { val: 7 }
     }
+
     function* emptyGenerator() {
       // Nothing
     }

--- a/src/utils/hashing.ts
+++ b/src/utils/hashing.ts
@@ -119,6 +119,7 @@ function x64LeftShift(m: number[], bits: number): void {
     m[1] = 0
   }
 }
+
 /**
  * Provides a XOR of the given int64 values(provided as tuple of two int32).
  * Result is written back to the first value


### PR DESCRIPTION
There is an ESLint rule that defines the desired linting outcome for "Enforce padding between function definitions." 
I believe it's desirable to have this added to avoid similar [issues](https://github.com/fingerprintjs/fingerprintjs/pull/1072/files#r1934181801) with "human-reviewer (not) linting the code" in the future.