### PR TITLE
Fix link to the publish action to point to fingerprintjs instead of fingerprintjs-pro repo

### DIFF
--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -8,7 +8,7 @@ This guide is for repository maintainers.
     Open the archive and make sure it contains the distribution files and no excess files.
     If there is something wrong, fix it and push to the PR.
 3. When the PR checks succeed and the PR is approved, merge it.
-4. Run the [Publish to NPM](https://github.com/fingerprintjs/fingerprintjs-pro/actions/workflows/npm_publish.yml) workflow by using the "Run workflow" button.
+4. Run the [Publish to NPM](https://github.com/fingerprintjs/fingerprintjs/actions/workflows/npm_publish.yml) workflow by using the "Run workflow" button.
     It will publish the current code to NPM and create a corresponding Git tag.
     The NPM version tag will be derived automatically from the package version, for example `1.2.3` gives `latest` and `1.2.3-alpha.1` gives `alpha`.
 5. Describe the version changes in the [releases section](https://github.com/fingerprintjs/fingerprintjs/releases) under the corresponding tag.


### PR DESCRIPTION
Fix link to the publish action to point to fingerprintjs instead of fingerprintjs-pro repo