### PR TITLE
Fix vendor undefined error

### DIFF
--- a/src/utils/browser.ts
+++ b/src/utils/browser.ts
@@ -59,7 +59,7 @@ export function isChromium(): boolean {
     countTruthy([
       'webkitPersistentStorage' in n,
       'webkitTemporaryStorage' in n,
-      (n.vendor || '').indexOf('Google') === 0,   
+      (n.vendor || '').indexOf('Google') === 0,
       'webkitResolveLocalFileSystemURL' in w,
       'BatteryManager' in w,
       'webkitMediaStream' in w,

--- a/src/utils/browser.ts
+++ b/src/utils/browser.ts
@@ -59,7 +59,7 @@ export function isChromium(): boolean {
     countTruthy([
       'webkitPersistentStorage' in n,
       'webkitTemporaryStorage' in n,
-      n.vendor.indexOf('Google') === 0,
+      (n.vendor || '').indexOf('Google') === 0,   
       'webkitResolveLocalFileSystemURL' in w,
       'BatteryManager' in w,
       'webkitMediaStream' in w,


### PR DESCRIPTION
We are seeing a large number of errors in Sentry for the Facebook browser where vendor is undefined. It is has been [deprecated ](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/vendor)so this issue will continue to amplify in the future
![image](https://github.com/user-attachments/assets/39bfdfaf-c87e-494a-b703-8ec6b88fbd32)