### PR TITLE
Fix: Add new Error when inside sandboxed iframe

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -1,8 +1,10 @@
 import { version } from '../package.json'
 import { requestIdleCallbackIfAvailable } from './utils/async'
+import { ERROR_SANDBOX_NOT_ALLOWED } from './constants'
 import { UnknownComponents } from './utils/entropy_source'
 import { x64hash128 } from './utils/hashing'
 import { errorToObject } from './utils/misc'
+import { isInsideSandboxIframe } from './utils/dom'
 import loadBuiltinSources, { BuiltinComponents } from './sources'
 import getConfidence, { Confidence } from './confidence'
 
@@ -196,6 +198,10 @@ function monitor() {
  * Builds an instance of Agent and waits a delay required for a proper operation.
  */
 export async function load(options: Readonly<LoadOptions> = {}): Promise<Agent> {
+  if (isInsideSandboxIframe()) {
+    throw new Error(ERROR_SANDBOX_NOT_ALLOWED)
+  }
+
   if ((options as { monitoring?: boolean }).monitoring ?? true) {
     monitor()
   }

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,0 +1,1 @@
+export const ERROR_SANDBOX_NOT_ALLOWED = 'FingerprintJS cannot work in sandboxed iframes'

--- a/src/utils/dom.test.ts
+++ b/src/utils/dom.test.ts
@@ -1,4 +1,4 @@
-import { addStyleString, isAnyParentCrossOrigin, withIframe } from './dom'
+import { addStyleString, isAnyParentCrossOrigin, withIframe, isInsideSandboxIframe } from './dom'
 import { withMockProperties } from '../../tests/utils'
 
 describe('DOM utilities', () => {
@@ -37,6 +37,27 @@ describe('DOM utilities', () => {
       } finally {
         jasmine.clock().uninstall()
       }
+    })
+  })
+
+  describe('isInsideSandboxIframe', () => {
+    // We are only mocking the window.origin because it is not possible to mock window.location
+    // And even if you somehow mock it when you try to set it back it would perform a page reload
+    const mockWindowOrigin = (origin: string) => ({
+      origin: { get: () => origin },
+    })
+
+    // The unit tests are done in 'http:' protocol by default
+    it('returns true "null" origin', async () => {
+      await withMockProperties(window, mockWindowOrigin('null'), () => {
+        expect(isInsideSandboxIframe()).toBeTrue()
+      })
+    })
+
+    it('returns false when both conditions are not met', async () => {
+      await withMockProperties(window, mockWindowOrigin('https://example.com'), () => {
+        expect(isInsideSandboxIframe()).toBeFalse()
+      })
     })
   })
 })

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -146,3 +146,8 @@ export function isAnyParentCrossOrigin(): boolean {
     currentWindow = parentWindow
   }
 }
+
+export function isInsideSandboxIframe() {
+  const w = window
+  return w.origin === 'null' && (w.location?.protocol === 'https:' || w.location?.protocol === 'http:')
+}


### PR DESCRIPTION
**Description:**

This PR introduces a new Error `FingerprintJS cannot work in sandboxed iframes` for cases when we are inside sandboxed iframe. The sandboxed iframe is an `iframe` element with the `sandbox` property, here is an example of HTML page with such iframe:

```html
<!DOCTYPE html>
<html lang="en">
<head>
    <meta charset="UTF-8">
    <meta name="viewport" content="width=device-width, initial-scale=1.0">
</head>
<body>
    <script>
        const iframe = document.createElement("iframe");
        iframe.sandbox = "allow-scripts";
        iframe.src = "http://localhost:8080/"; // the FingerprintJS playground may run here
        document.body.appendChild(iframe);
    </script>
</body>
</html>
```
When we are in such environment then a lot of components would not work properly, for example the `fonts` would fail with this error:

```
"error": {
      "name": "SecurityError",
      "message": "Failed to read a named property 'document' from 'Window': Blocked a frame with origin \"null\" from accessing a cross-origin frame.",
      "stack": [
        "SecurityError: Failed to read a named property 'document' from 'Window': Blocked a frame with origin \"null\" from accessing a cross-origin frame.",
        "    at step (http://localhost:8080/main.js?31b76f77eb444b048247:5424:23)",
        "    at Object.next (http://localhost:8080/main.js?31b76f77eb444b048247:5405:53)",
        "    at fulfilled (http://localhost:8080/main.js?31b76f77eb444b048247:5395:58)"
      ]
    },
```
So, it is more convenient to simply throw an error if we are in such environment. Otherwise we would need to always think about such case and address it per component which is not optimal.

### Key Changes:
**New error was introduced**
  - Added new Error constant `FingerprintJS cannot work in sandboxed iframes`
  - Added `isInsideSandboxIframe` function in `utils/dom.ts`


### Testing:
- Add a corresponding tests for a `isInsideSandboxIframe`. Please note, that the tests are not mocking `window.location` because it is not practical (the karma is running our test on `http:` protocol already) and overly complicated.
