### PR TITLE
Chore(build): Set compilation target to ES2018 & remove tslib dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,9 +44,6 @@
     "check:dts": "tsc --isolatedModules --noEmit dist/fp.d.ts",
     "check:ssr": "node --require './dist/fp.cjs.js' --eval '' || (echo \"The distributive files can't be used with server side rendering. Make sure the code doesn't use browser API until an exported function is called.\" && exit 1)"
   },
-  "dependencies": {
-    "tslib": "^2.4.1"
-  },
   "devDependencies": {
     "@fpjs-incubator/broyster": "^0.2.3",
     "@rollup/plugin-json": "^5.0.1",

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -8,7 +8,8 @@ import dtsPlugin from 'rollup-plugin-dts'
 import licensePlugin from 'rollup-plugin-license'
 import terserConfig from './terser.config'
 
-const { dependencies } = JSON.parse(fs.readFileSync('package.json', 'utf8'))
+const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'))
+const dependencies = pkg.dependencies || {}
 
 const outputDirectory = 'dist'
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,10 +2,10 @@
   "compilerOptions": {
     "module": "esnext",
     "moduleResolution": "node16",
-    "target": "es5",
+    "target": "es2018",
     "removeComments": false,
     "resolveJsonModule": true,
-    "importHelpers": true,
+    "importHelpers": false,
     "noErrorTruncation": true,
     "strict": true,
     "noUnusedLocals": true,


### PR DESCRIPTION
This pull request introduces two build-related changes aimed at simplifying the codebase and reducing unnecessary dependencies and output size of produced bundles.

### Changes:

**Updated TypeScript compilation target to ES2018**
The project now compiles directly to ES2018, which is a well-supported baseline for modern browsers. This target provides native support for:
- async/await
- Object.entries, Object.values
- for...of on built-ins
...

This eliminates the need to "downlevel" modern JavaScript features, reducing output size (and complexity).

**Removed tslib dependency**
- Even with `tslib` (still) installed and `importHelpers: true`, when targeting ES2018, the final bundles no longer include references to `tslib`, as the emitted code relies solely on native JavaScript features.
- Since tslib is removed and `importHelpers` option is now disabled and our compilation target is ES2018, the TypeScript compiler no longer injects helper functions that require tslib.

<img width="688" height="704" alt="final" src="https://github.com/user-attachments/assets/b2b79884-854c-4398-aea5-b5a6c3cd16e7" />
