### PR TITLE
Fix: Update Canvas Test to Handle Samsung28

### DIFF
--- a/src/sources/canvas.test.ts
+++ b/src/sources/canvas.test.ts
@@ -36,7 +36,7 @@ function shouldSkip() {
 }
 
 function shouldBeUnstable() {
-  return isSamsungInternet()
+  return isSamsungInternet() && (getBrowserMajorVersion() ?? 0) < 28
 }
 
 function isDataURL(url: string) {


### PR DESCRIPTION
On Samsung 28 we have the stable images [here](https://github.com/fingerprintjs/fingerprintjs/blob/master/src/sources/canvas.ts#L81) in normal mode (not sure about a private one, we will check it and adjust if needed in a separate PR). So, I updated the test to exclude it from `shouldBeUnstable`

We need to re-confirm it as the issue might be on the Browserstack side.