### PR TITLE
Fixed zoom altering the font preferences signal in newer Chrome

### DIFF
--- a/src/sources/font_preferences.ts
+++ b/src/sources/font_preferences.ts
@@ -78,16 +78,13 @@ export default function getFontPreferences(): Promise<Record<string, number>> {
 
     // Then measure the created elements
     // For Chromium 128+: multiply by devicePixelRatio to reverse the CSS zoom effect
-    if (isChromium() && isChromium128OrNewer()) {
-      for (const key of Object.keys(presets)) {
-        const rawWidth = elements[key].getBoundingClientRect().width
-        sizes[key] = roundFontMeasurement(rawWidth * iframeWindow.devicePixelRatio)
-      }
-    } else {
-      // Firefox/Safari/older Chrome: CSS zoom is applied ('reset' for WebKit), use raw measurements
-      for (const key of Object.keys(presets)) {
-        sizes[key] = elements[key].getBoundingClientRect().width
-      }
+    // Firefox/Safari/older Chrome: CSS zoom is applied ('reset' for WebKit), use raw measurements
+    const shouldNormalizeMeasurement = isChromium() && isChromium128OrNewer()
+    for (const key of Object.keys(presets)) {
+      const rawWidth = elements[key].getBoundingClientRect().width
+      sizes[key] = shouldNormalizeMeasurement
+        ? normalizeFontMeasurement(rawWidth * iframeWindow.devicePixelRatio)
+        : rawWidth
     }
 
     return sizes
@@ -99,7 +96,7 @@ export default function getFontPreferences(): Promise<Record<string, number>> {
  * - On Android: rounds to whole numbers for maximum stability across devices
  * - On other platforms: rounds down to 3 decimal places
  */
-function roundFontMeasurement(value: number): number {
+function normalizeFontMeasurement(value: number): number {
   const decimals = isAndroid() ? 0 : 3
   const pow = Math.pow(10, decimals)
   return Math.floor(value * pow) / pow

--- a/src/sources/font_preferences.ts
+++ b/src/sources/font_preferences.ts
@@ -161,8 +161,7 @@ function withNaturalFonts<T>(
 
     const bodyStyle = iframeBody.style
     bodyStyle.width = `${containerWidthPx}px`
-    bodyStyle.webkitTextSizeAdjust = 'none'
-    bodyStyle.setProperty('text-size-adjust', 'none')
+    bodyStyle.webkitTextSizeAdjust = bodyStyle.textSizeAdjust = 'none'
 
     // See the big comment above
     if (isChromium()) {

--- a/src/sources/font_preferences.ts
+++ b/src/sources/font_preferences.ts
@@ -1,4 +1,4 @@
-import { isChromium, isWebKit } from '../utils/browser'
+import { isChromium, isChromium128OrNewer, isWebKit } from '../utils/browser'
 import { withIframe } from '../utils/dom'
 import { MaybePromise } from '../utils/async'
 
@@ -52,7 +52,7 @@ export const presets: Record<string, Preset> = {
  * The "min" and the "mono" (only on Windows) value may change when the page is zoomed in Firefox 87.
  */
 export default function getFontPreferences(): Promise<Record<string, number>> {
-  return withNaturalFonts((document, container) => {
+  return withNaturalFonts((document, container, iframeWindow) => {
     const elements: Record<string, HTMLElement> = {}
     const sizes: Record<string, number> = {}
 
@@ -77,12 +77,29 @@ export default function getFontPreferences(): Promise<Record<string, number>> {
     }
 
     // Then measure the created elements
-    for (const key of Object.keys(presets)) {
-      sizes[key] = elements[key].getBoundingClientRect().width
+    // For Chromium 128+: multiply by devicePixelRatio to reverse the CSS zoom effect
+    if (isChromium() && isChromium128OrNewer()) {
+      for (const key of Object.keys(presets)) {
+        const rawWidth = elements[key].getBoundingClientRect().width
+        sizes[key] = roundFontMeasurement(rawWidth * iframeWindow.devicePixelRatio)
+      }
+    } else {
+      for (const key of Object.keys(presets)) {
+        const rawWidth = elements[key].getBoundingClientRect().width
+        sizes[key] = roundFontMeasurement(rawWidth)
+      }
     }
 
     return sizes
   })
+}
+
+/**
+ * Round font measurement values to reduce floating-point errors and maintain stability
+ * Uses Math.floor with 3 decimal places to always round down consistently
+ */
+function roundFontMeasurement(value: number): number {
+  return Math.floor(value * 1000) / 1000
 }
 
 /**
@@ -91,7 +108,7 @@ export default function getFontPreferences(): Promise<Record<string, number>> {
  * Don't put a content to measure inside an absolutely positioned element.
  */
 function withNaturalFonts<T>(
-  action: (document: Document, container: HTMLElement) => MaybePromise<T>,
+  action: (document: Document, container: HTMLElement, iframeWindow: Window) => MaybePromise<T>,
   containerWidthPx = 4000,
 ): Promise<T> {
   /*
@@ -144,7 +161,8 @@ function withNaturalFonts<T>(
 
     const bodyStyle = iframeBody.style
     bodyStyle.width = `${containerWidthPx}px`
-    bodyStyle.webkitTextSizeAdjust = bodyStyle.textSizeAdjust = 'none'
+    bodyStyle.webkitTextSizeAdjust = 'none'
+    bodyStyle.setProperty('text-size-adjust', 'none')
 
     // See the big comment above
     if (isChromium()) {
@@ -158,6 +176,6 @@ function withNaturalFonts<T>(
     linesOfText.textContent = [...Array((containerWidthPx / 20) << 0)].map(() => 'word').join(' ')
     iframeBody.appendChild(linesOfText)
 
-    return action(iframeDocument, iframeBody)
+    return action(iframeDocument, iframeBody, iframeWindow)
   }, '<!doctype html><html><head><meta name="viewport" content="width=device-width, initial-scale=1">')
 }

--- a/src/sources/font_preferences.ts
+++ b/src/sources/font_preferences.ts
@@ -1,4 +1,4 @@
-import { isChromium, isChromium128OrNewer, isWebKit } from '../utils/browser'
+import { isAndroid, isChromium, isChromium128OrNewer, isWebKit } from '../utils/browser'
 import { withIframe } from '../utils/dom'
 import { MaybePromise } from '../utils/async'
 
@@ -84,9 +84,9 @@ export default function getFontPreferences(): Promise<Record<string, number>> {
         sizes[key] = roundFontMeasurement(rawWidth * iframeWindow.devicePixelRatio)
       }
     } else {
+      // Firefox/Safari/older Chrome: CSS zoom is applied ('reset' for WebKit), use raw measurements
       for (const key of Object.keys(presets)) {
-        const rawWidth = elements[key].getBoundingClientRect().width
-        sizes[key] = roundFontMeasurement(rawWidth)
+        sizes[key] = elements[key].getBoundingClientRect().width
       }
     }
 
@@ -96,10 +96,13 @@ export default function getFontPreferences(): Promise<Record<string, number>> {
 
 /**
  * Round font measurement values to reduce floating-point errors and maintain stability
- * Uses Math.floor with 3 decimal places to always round down consistently
+ * - On Android: rounds to whole numbers for maximum stability across devices
+ * - On other platforms: rounds down to 3 decimal places
  */
 function roundFontMeasurement(value: number): number {
-  return Math.floor(value * 1000) / 1000
+  const decimals = isAndroid() ? 0 : 3
+  const pow = Math.pow(10, decimals)
+  return Math.floor(value * pow) / pow
 }
 
 /**

--- a/src/sources/font_preferences.ts
+++ b/src/sources/font_preferences.ts
@@ -92,7 +92,7 @@ export default function getFontPreferences(): Promise<Record<string, number>> {
 }
 
 /**
- * Round font measurement values to reduce floating-point errors and maintain stability
+ * Floor font measurement values to reduce floating-point errors and maintain stability
  * - On Android: rounds to whole numbers for maximum stability across devices
  * - On other platforms: rounds down to 3 decimal places
  */

--- a/src/utils/browser.test.ts
+++ b/src/utils/browser.test.ts
@@ -44,6 +44,13 @@ describe('Browser utilities', () => {
       expect(browser.isChromium122OrNewer()).toBe((utils.getBrowserEngineMajorVersion() ?? 0) >= 122)
     })
 
+    it('detects Chromium 128+', () => {
+      if (!utils.isChromium()) {
+        return
+      }
+      expect(browser.isChromium128OrNewer()).toBe((utils.getBrowserEngineMajorVersion() ?? 0) >= 128)
+    })
+
     // WebKit has stopped telling its real version in the user-agent string since version 605.1.15,
     // therefore the browser version has to be checked instead of the engine version.
     it('detects Safari 12+', () => {

--- a/src/utils/browser.ts
+++ b/src/utils/browser.ts
@@ -256,6 +256,26 @@ export function isChromium122OrNewer(): boolean {
 }
 
 /**
+ * Checks whether the browser is based on Chromium version ≥128 without using user-agent.
+ * It doesn't check that the browser is based on Chromium, there is a separate function for this.
+ */
+export function isChromium128OrNewer(): boolean {
+  // Checked in Chrome 127 vs Chrome 128+
+  const w = window
+  const d = document
+  const { CSS, Promise, AudioContext } = w
+
+  return (
+    countTruthy([
+      Promise && 'try' in Promise,
+      'caretPositionFromPoint' in d,
+      AudioContext && 'onerror' in AudioContext.prototype,
+      CSS.supports('ruby-align', 'space-around'),
+    ]) >= 3
+  )
+}
+
+/**
  * Checks whether the browser is based on WebKit version ≥606 (Safari ≥12) without using user-agent.
  * It doesn't check that the browser is based on WebKit, there is a separate function for this.
  *


### PR DESCRIPTION
Fix for: Unstable font preferences component when zooming the page in Chrome 146

After investigation this issue persists from Chrome version 128, but wasn't caught earlier. The cause of the issue is that css zoom preference is now altering the font width which is changing the values and thus leading to different IDs. In order to fix this we need to normalize the collected values with device DPR. This PR is a partial fix, only for Chrome browser for https://github.com/fingerprintjs/fingerprintjs/issues/98