### PR TITLE
fix: add timeout and error handlers to XHR in monitor()

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -188,6 +188,9 @@ function monitor() {
   }
   try {
     const request = new XMLHttpRequest()
+    request.timeout = 5000
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    request.onerror = request.ontimeout = () => {}
     request.open('get', `https://m1.openfpcdn.io/fingerprintjs/v${version}/npm-monitoring`, true)
     request.send()
   } catch (error) {


### PR DESCRIPTION
### What does this PR do?

Fixes a bug in `monitor()` (`src/agent.ts`) where the fire-and-forget stats `XMLHttpRequest` had no timeout and no async error handlers.

**Before:**
- `request.timeout` was never set → a stalled connection could hang indefinitely.
- `request.onerror` / `request.ontimeout` were never assigned → async network failures were silently missed (the outer `try/catch` only covers synchronous errors thrown by `open()`/`send()`).

**After:**
- `request.timeout = 5000` — stalled requests are cancelled after 5 s.
- `request.onerror = request.ontimeout = () => {}` — async failures are explicitly (and intentionally) ignored. This is appropriate for a best-effort stats ping where errors should never surface to library consumers.

### Changes

```diff
-    const request = new XMLHttpRequest()
-    request.open('get', `https://m1.openfpcdn.io/fingerprintjs/v${version}/npm-monitoring`, true)
-    request.send()
+    const request = new XMLHttpRequest()
+    request.timeout = 5000
+    request.onerror = request.ontimeout = () => {}
+    request.open('get', `https://m1.openfpcdn.io/fingerprintjs/v${version}/npm-monitoring`, true)
+    request.send()
```

### Related issue

Closes https://github.com/fingerprintjs/fingerprintjs/issues/1156

### Checklist

- [x] Code quality is at least as good as the existing code
- [x] Code style follows FingerprintJS conventions
- [x] Change is backward compatible
- [x] No new dependencies added
- [x] Change is limited to the stated purpose (no unrelated modifications)
