### PR TITLE
fix: replace __proto__ with Object.getPrototypeOf() in getConstantsFromPrototype()

### DIFF
--- a/src/sources/webgl.ts
+++ b/src/sources/webgl.ts
@@ -225,8 +225,11 @@ function getShaderPrecision(
 }
 
 function getConstantsFromPrototype<K>(obj: K): Array<Extract<keyof K, string>> {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const keys = Object.keys((obj as any).__proto__) as Array<keyof K>
+  const proto = Object.getPrototypeOf(obj) as K | null
+  if (!proto) {
+    return []
+  }
+  const keys = Object.keys(proto) as Array<keyof K>
   return keys.filter(isConstantLike)
 }
 


### PR DESCRIPTION
### What does this PR do?

Replaces the legacy `__proto__` access in `getConstantsFromPrototype()` (`src/sources/webgl.ts`) with the spec-compliant `Object.getPrototypeOf()`.

**Before:**

```typescript
function getConstantsFromPrototype<K>(obj: K): Array<Extract<keyof K, string>> {
  // eslint-disable-next-line @typescript-eslint/no-explicit-any
  const keys = Object.keys((obj as any).__proto__) as Array<keyof K>
  return keys.filter(isConstantLike)
}
```

Problems with the old code:
1. **`__proto__` is non-standard** — it is Annex B (legacy web compatibility) and not guaranteed in all environments.
2. **Crashes on null-prototype objects** — `(Object.create(null) as any).__proto__` is `undefined`; `Object.keys(undefined)` throws `TypeError`.
3. **Hidden by `as any`** — TypeScript cannot surface the hazard.

**After:**

```typescript
function getConstantsFromPrototype<K>(obj: K): Array<Extract<keyof K, string>> {
  const proto = Object.getPrototypeOf(obj) as K | null
  if (!proto) {
    return []
  }
  const keys = Object.keys(proto) as Array<keyof K>
  return keys.filter(isConstantLike)
}
```

`Object.getPrototypeOf()` is the standard ES5+ API for prototype introspection. The null-guard ensures the function degrades gracefully for null-prototype objects instead of throwing.

### Changes

- `src/sources/webgl.ts` — replace `__proto__` access with `Object.getPrototypeOf()` and add null-prototype guard.

### Related issue

Closes https://github.com/fingerprintjs/fingerprintjs/issues/1160

### Checklist

- [x] Code quality is at least as good as the existing code
- [x] Code style follows FingerprintJS conventions
- [x] Change is backward compatible
- [x] No new dependencies added
- [x] Change is limited to the stated purpose (no unrelated modifications)
