### PR TITLE
fix: guard DOMException instanceof check with typeof in user_agent_data.ts

### DIFF
--- a/src/sources/user_agent_data.ts
+++ b/src/sources/user_agent_data.ts
@@ -75,7 +75,7 @@ export default async function getUserAgentData(): Promise<StableUserAgentData | 
       result.model = highEntropy.model
       result.platformVersion = highEntropy.platformVersion
     } catch (error) {
-      if (error instanceof DOMException && error.name === 'NotAllowedError') {
+      if (typeof DOMException !== 'undefined' && error instanceof DOMException && error.name === 'NotAllowedError') {
         result.highEntropyStatus = HighEntropyStatus.NotAllowed
       } else {
         throw error


### PR DESCRIPTION
### What does this PR do?

Fixes a compatibility bug in `src/sources/user_agent_data.ts` where an unguarded `instanceof DOMException` check can throw a `ReferenceError` in environments where `DOMException` is not defined.

**Before:**

```typescript
} catch (error) {
  if (error instanceof DOMException && error.name === 'NotAllowedError') {
    result.highEntropyStatus = HighEntropyStatus.NotAllowed
  } else {
    throw error
  }
}
```

In environments where `DOMException` is `undefined` (older browsers, SSR, certain WebViews), the `instanceof` expression throws:
```
ReferenceError: DOMException is not defined
```
This converts a gracefully-handled permission-denial into an unhandled exception.

**After:**

```diff
- if (error instanceof DOMException && error.name === 'NotAllowedError') {
+ if (typeof DOMException !== 'undefined' && error instanceof DOMException && error.name === 'NotAllowedError') {
```

`typeof` never throws even for undeclared identifiers. JavaScript's `&&` short-circuits, so the `instanceof` is only evaluated when `DOMException` is known to exist. No behaviour change in environments where `DOMException` is present.

### Changes

- `src/sources/user_agent_data.ts` — one-line change adding a `typeof DOMException !== 'undefined'` guard.

### Related issue

Closes https://github.com/fingerprintjs/fingerprintjs/issues/1162

### Checklist

- [x] Code quality is at least as good as the existing code
- [x] Code style follows FingerprintJS conventions
- [x] Change is backward compatible
- [x] No new dependencies added
- [x] Change is limited to the stated purpose (no unrelated modifications)
