### PR TITLE
fix: use a monotonic boolean to guard watchScreenFrame() re-entry

### DIFF
--- a/src/sources/screen_frame.ts
+++ b/src/sources/screen_frame.ts
@@ -22,6 +22,7 @@ const roundingPrecision = 10
 // The type is readonly to protect from unwanted mutations
 let screenFrameBackup: Readonly<FrameSize> | undefined
 let screenFrameSizeTimeoutId: number | undefined
+let screenFrameWatchStarted = false
 
 /**
  * Starts watching the screen frame size. When a non-zero size appears, the size is saved and the watch is stopped.
@@ -31,9 +32,10 @@ let screenFrameSizeTimeoutId: number | undefined
  * See more on this at https://github.com/fingerprintjs/fingerprintjs/issues/568
  */
 function watchScreenFrame() {
-  if (screenFrameSizeTimeoutId !== undefined) {
+  if (screenFrameWatchStarted) {
     return
   }
+  screenFrameWatchStarted = true
   const checkScreenFrame = () => {
     const frameSize = getCurrentScreenFrame()
     if (isFrameSizeNull(frameSize)) {
@@ -55,6 +57,7 @@ export function resetScreenFrameWatch(): void {
     screenFrameSizeTimeoutId = undefined
   }
   screenFrameBackup = undefined
+  screenFrameWatchStarted = false
 }
 
 /**


### PR DESCRIPTION
### What does this PR do?

Fixes a guard-logic bug in `watchScreenFrame()` (`src/sources/screen_frame.ts`) where the "already started" check could be bypassed after the watch cycle completed, allowing a redundant poll loop to start.

**Root cause:**

The guard relied on `screenFrameSizeTimeoutId !== undefined`:

```typescript
function watchScreenFrame() {
  if (screenFrameSizeTimeoutId !== undefined) return  // guard
  ...
  const checkScreenFrame = () => {
    ...
    } else {
      screenFrameBackup = frameSize
      screenFrameSizeTimeoutId = undefined   // ← guard resets here
    }
  }
}
```

Once a non-null frame is found, `screenFrameSizeTimeoutId` is cleared back to `undefined` and `screenFrameBackup` is populated. Any subsequent call to `watchScreenFrame()` at that point (e.g. from a second `load()` call or a future `getUnstableScreenFrame()` invocation) passes the guard and starts a new, redundant poll loop — even though the work is already done.

**Fix:**

Introduce a separate `screenFrameWatchStarted` boolean that is set to `true` on first entry and **never resets to `false`** during normal operation:

```diff
+ let screenFrameWatchStarted = false

 function watchScreenFrame() {
-  if (screenFrameSizeTimeoutId !== undefined) {
+  if (screenFrameWatchStarted) {
     return
   }
+  screenFrameWatchStarted = true
   ...
 }

 export function resetScreenFrameWatch(): void {
   ...
   screenFrameBackup = undefined
+  screenFrameWatchStarted = false   // reset for test isolation only
 }
```

The polling and backup logic are entirely unchanged. Only the entry guard is made reliably monotonic.

### Changes

- `src/sources/screen_frame.ts` — add `screenFrameWatchStarted` boolean; replace timer-ID guard in `watchScreenFrame()`; reset the boolean in `resetScreenFrameWatch()`.

### Related issue

Closes https://github.com/fingerprintjs/fingerprintjs/issues/1164

### Checklist

- [x] Code quality is at least as good as the existing code
- [x] Code style follows FingerprintJS conventions
- [x] Change is backward compatible
- [x] No new dependencies added
- [x] Change is limited to the stated purpose (no unrelated modifications)
