### PR TITLE
fix: cap total audio render retries and clear pending timer on finalize

### DIFF
--- a/src/sources/audio.ts
+++ b/src/sources/audio.ts
@@ -118,6 +118,7 @@ function doesBrowserPerformAntifingerprinting() {
  */
 function startRenderingAudio(context: OfflineAudioContext) {
   const renderTryMaxCount = 3
+  const renderTotalTryMaxCount = renderTryMaxCount * 3 // absolute cap including background retries
   const renderRetryDelay = 500
   const runningMaxAwaitTime = 500
   const runningSufficientTime = 5000
@@ -126,6 +127,8 @@ function startRenderingAudio(context: OfflineAudioContext) {
   const resultPromise = new Promise<AudioBuffer>((resolve, reject) => {
     let isFinalized = false
     let renderTryCount = 0
+    let totalRenderTryCount = 0
+    let retryTimeoutId: ReturnType<typeof setTimeout> | undefined
     let startedRunningAt = 0
 
     context.oncomplete = (event) => resolve(event.renderedBuffer)
@@ -138,6 +141,7 @@ function startRenderingAudio(context: OfflineAudioContext) {
     }
 
     const tryRender = () => {
+      retryTimeoutId = undefined
       try {
         const renderingPromise = context.startRendering()
 
@@ -166,10 +170,14 @@ function startRenderingAudio(context: OfflineAudioContext) {
             if (!document.hidden) {
               renderTryCount++
             }
-            if (isFinalized && renderTryCount >= renderTryMaxCount) {
+            totalRenderTryCount++
+            if (
+              (isFinalized && renderTryCount >= renderTryMaxCount) ||
+              totalRenderTryCount >= renderTotalTryMaxCount
+            ) {
               reject(makeInnerError(InnerErrorName.Suspended))
             } else {
-              setTimeout(tryRender, renderRetryDelay)
+              retryTimeoutId = (setTimeout as typeof window.setTimeout)(tryRender, renderRetryDelay)
             }
             break
         }
@@ -183,6 +191,10 @@ function startRenderingAudio(context: OfflineAudioContext) {
     finalize = () => {
       if (!isFinalized) {
         isFinalized = true
+        if (retryTimeoutId !== undefined) {
+          clearTimeout(retryTimeoutId)
+          retryTimeoutId = undefined
+        }
         if (startedRunningAt > 0) {
           startRunningTimeout()
         }


### PR DESCRIPTION
### What does this PR do?

Fixes two related resource-leak issues in `startRenderingAudio()` (`src/sources/audio.ts`).

---

#### Problem 1 — Unbounded retry loop when tab is hidden

When `context.state === 'suspended'` and `document.hidden === true`, the foreground retry counter `renderTryCount` is intentionally not incremented (the comment explains this is by design — the context waits patiently for the tab to come back). However the abort condition only checks the foreground count:

```typescript
if (isFinalized && renderTryCount >= renderTryMaxCount) {
  reject(...)
} else {
  setTimeout(tryRender, renderRetryDelay)   // always retries
}
```

If the tab **stays hidden indefinitely**, `renderTryCount` never reaches `renderTryMaxCount`, so the retry loop runs forever, keeping the `OfflineAudioContext`, its entire promise chain, and all closure variables alive until the page is closed.

**Fix:** Add `renderTotalTryMaxCount = renderTryMaxCount * 3` and a `totalRenderTryCount` counter that always increments regardless of visibility. The abort condition now also checks this absolute ceiling:

```typescript
totalRenderTryCount++
if (
  (isFinalized && renderTryCount >= renderTryMaxCount) ||
  totalRenderTryCount >= renderTotalTryMaxCount
) {
  reject(makeInnerError(InnerErrorName.Suspended))
} else {
  retryTimeoutId = (setTimeout as typeof window.setTimeout)(tryRender, renderRetryDelay)
}
```

---

#### Problem 2 — Pending retry timer is never cleared

The return value of `setTimeout(tryRender, renderRetryDelay)` was discarded. If the promise resolved via `context.oncomplete` (or was rejected by another path) while a retry was still queued, the pending callback would fire anyway and call `context.startRendering()` on an already-completed context.

**Fix:** Store the pending timer ID in `retryTimeoutId`. Clear it at the top of each `tryRender()` invocation (the timer has now fired, so it's no longer pending), and also inside `finalize()` so a successful render cancels any outstanding background retry:

```typescript
finalize = () => {
  if (!isFinalized) {
    isFinalized = true
    if (retryTimeoutId !== undefined) {
      clearTimeout(retryTimeoutId)
      retryTimeoutId = undefined
    }
    if (startedRunningAt > 0) {
      startRunningTimeout()
    }
  }
}
```

---

### Changes

- `src/sources/audio.ts`
  - Add `renderTotalTryMaxCount` constant.
  - Add `totalRenderTryCount` and `retryTimeoutId` variables.
  - Increment `totalRenderTryCount` on every suspended retry.
  - Enforce the absolute cap.
  - Store and clear the retry timer ID.

### Related issue

Closes https://github.com/fingerprintjs/fingerprintjs/issues/1166

### Checklist

- [x] Code quality is at least as good as the existing code
- [x] Code style follows FingerprintJS conventions
- [x] Change is backward compatible (background fingerprinting may now time out with `Suspended` if retried 9+ times; this is strictly better than an unbounded loop)
- [x] No new dependencies added
- [x] Change is limited to the stated purpose (no unrelated modifications)
