### PR TITLE
fix: replace deprecated execCommand('copy') with Clipboard API in playground

### DIFF
--- a/playground/index.ts
+++ b/playground/index.ts
@@ -120,18 +120,27 @@ function initializeDebugButtons(debugText: string) {
   }
 }
 
-function copy(text: string) {
-  const textarea = document.createElement('textarea')
-  textarea.value = text
-  document.body.appendChild(textarea)
-  textarea.focus()
-  textarea.select()
-  try {
-    document.execCommand('copy')
-  } catch {
-    // Do nothing in case of a copying error
+async function copy(text: string) {
+  if (navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text)
+    } catch {
+      // Do nothing in case of a copying error
+    }
+  } else {
+    // Legacy fallback for browsers that don't support the Clipboard API
+    const textarea = document.createElement('textarea')
+    textarea.value = text
+    document.body.appendChild(textarea)
+    textarea.focus()
+    textarea.select()
+    try {
+      document.execCommand('copy')
+    } catch {
+      // Do nothing in case of a copying error
+    }
+    document.body.removeChild(textarea)
   }
-  document.body.removeChild(textarea)
 }
 
 async function share(text: string) {


### PR DESCRIPTION
### What does this PR do?

Replaces the deprecated `document.execCommand('copy')` call in the `copy()` helper (`playground/index.ts`) with the modern [Clipboard API](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API), keeping the old path as a fallback.

**Before:**

```typescript
function copy(text: string) {
  const textarea = document.createElement('textarea')
  textarea.value = text
  document.body.appendChild(textarea)
  textarea.focus()
  textarea.select()
  try {
    document.execCommand('copy')
  } catch {
    // Do nothing in case of a copying error
  }
  document.body.removeChild(textarea)
}
```

`document.execCommand` is [deprecated](https://developer.mozilla.org/en-US/docs/Web/API/Document/execCommand). Browsers already print deprecation warnings and may remove support in future versions.

**After:**

```typescript
async function copy(text: string) {
  if (navigator.clipboard?.writeText) {
    try {
      await navigator.clipboard.writeText(text)
    } catch {
      // Do nothing in case of a copying error
    }
  } else {
    // Legacy fallback for browsers that don't support the Clipboard API
    const textarea = document.createElement('textarea')
    textarea.value = text
    document.body.appendChild(textarea)
    textarea.focus()
    textarea.select()
    try {
      document.execCommand('copy')
    } catch {
      // Do nothing in case of a copying error
    }
    document.body.removeChild(textarea)
  }
}
```

- Modern browsers on HTTPS use `navigator.clipboard.writeText()`.
- The `execCommand` path is preserved in the `else` branch for HTTP origins and older browsers — no regression for any previously-supported environment.
- The function is now `async` to correctly `await` the Clipboard API promise; callers that don't await it continue to work (fire-and-forget is fine for a copy button).

### Changes

- `playground/index.ts` — `copy()` converted to `async`, Clipboard API used as primary path, `execCommand` kept as fallback.

### Related issue

Closes https://github.com/fingerprintjs/fingerprintjs/issues/1168

### Checklist

- [x] Code quality is at least as good as the existing code
- [x] Code style follows FingerprintJS conventions
- [x] Change is backward compatible
- [x] No new dependencies added
- [x] Change is limited to the stated purpose (no unrelated modifications)
