### PR TITLE
Revert "Fixed sinhPf returning wrong value due to operator precedence"

### DIFF
--- a/src/sources/math.test.ts
+++ b/src/sources/math.test.ts
@@ -43,11 +43,6 @@ describe('Sources', () => {
       expect(sum).not.toBe(0)
     })
 
-    it('returns the correct sinh polyfill value', () => {
-      const data = getMathFingerprint()
-      expect(data.sinhPf).toBeCloseTo(1.1752011936438014, 10)
-    })
-
     it('returns stable values', () => {
       const first = getMathFingerprint()
       const second = getMathFingerprint()

--- a/src/sources/math.ts
+++ b/src/sources/math.ts
@@ -28,7 +28,7 @@ export default function getMathFingerprint(): Record<string, number> {
   const acoshPf = (value: number) => M.log(value + M.sqrt(value * value - 1))
   const asinhPf = (value: number) => M.log(value + M.sqrt(value * value + 1))
   const atanhPf = (value: number) => M.log((1 + value) / (1 - value)) / 2
-  const sinhPf = (value: number) => (M.exp(value) - 1 / M.exp(value)) / 2
+  const sinhPf = (value: number) => M.exp(value) - 1 / M.exp(value) / 2
   const coshPf = (value: number) => (M.exp(value) + 1 / M.exp(value)) / 2
   const expm1Pf = (value: number) => M.exp(value) - 1
   const tanhPf = (value: number) => (M.exp(2 * value) - 1) / (M.exp(2 * value) + 1)


### PR DESCRIPTION
Reverts fingerprintjs/fingerprintjs#1191

Reason:
- after some thinking and internal discussion within a team we decided that it is not worth it (as it will change all visitor IDs from before). The signal itself is fine even with "broken math"